### PR TITLE
Add Skia native assets to build output

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,6 +32,8 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="SkiaSharp" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.9" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="2.88.9" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="2.88.9" />
     <PackageVersion Include="Spectre.Console" Version="0.48.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="system.commandline" Version="2.0.0-beta4.22272.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,7 @@
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="SkiaSharp" Version="2.88.9" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.9" />
     <PackageVersion Include="Spectre.Console" Version="0.48.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="system.commandline" Version="2.0.0-beta4.22272.1" />

--- a/UndercutF1.Console/UndercutF1.Console.csproj
+++ b/UndercutF1.Console/UndercutF1.Console.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="system.commandline" />

--- a/UndercutF1.Console/UndercutF1.Console.csproj
+++ b/UndercutF1.Console/UndercutF1.Console.csproj
@@ -27,6 +27,8 @@
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" />
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="system.commandline" />


### PR DESCRIPTION
By depending on the SkiaSharp.NativeAssets packages, we can ensure that the Skia native libraries are properly packaged in to the executable.