### PR TITLE
Fix Windows related issued

### DIFF
--- a/UndercutF1.Console/CommandHandler.cs
+++ b/UndercutF1.Console/CommandHandler.cs
@@ -1,8 +1,8 @@
 using InMemLogger;
-using UndercutF1.Data;
 using Serilog;
 using Serilog.Events;
 using TextCopy;
+using UndercutF1.Data;
 
 namespace UndercutF1.Console;
 
@@ -16,9 +16,7 @@ public static partial class CommandHandler
         bool useConsoleLogging = false
     )
     {
-        var builder = WebApplication.CreateEmptyBuilder(
-            new() { ApplicationName = "undercutf1" }
-        );
+        var builder = WebApplication.CreateEmptyBuilder(new() { ApplicationName = "undercutf1" });
 
         var commandLineOpts = new Dictionary<string, string?>();
         if (isVerbose)


### PR DESCRIPTION
* Fix the weird issue with line endings that caused only a single line to display on Windows.

* Change the way we read in input from the terminal by first checking if input is available using the classic System.Console API, instead of relying on read cancellation on `Terminal.ReadAsync`. This is because cancelling the read causes a byte to drop on Windows (see https://github.com/vezel-dev/cathode/issues/165)