### PR TITLE
Improve session message handling

### DIFF
--- a/UndercutF1.Data/Client/JsonTimingClient.cs
+++ b/UndercutF1.Data/Client/JsonTimingClient.cs
@@ -140,8 +140,8 @@ public class JsonTimingClient(
 
         var delay =
             sessionStart > firstHeartbeatDateTime
-                ? DateTimeOffset.UtcNow - sessionStart
-                : DateTimeOffset.UtcNow - firstHeartbeatDateTime;
+                ? DateTime.UtcNow - sessionStart
+                : DateTime.UtcNow - firstHeartbeatDateTime;
 
         logger.LogInformation(
             "Calculated a delay of {Delay} from the highest of (SessionStart: {SessionStart:s}, FirstHeartbeat: {FirstHeartbeat:s})",

--- a/UndercutF1.Data/Client/TimingService.cs
+++ b/UndercutF1.Data/Client/TimingService.cs
@@ -85,6 +85,13 @@ public class TimingService(
                     Logger.LogError(ex, "Failed to process data {Data}", res);
                 }
             }
+            else
+            {
+                // No items in the queue to read. Instead of immediately checking,
+                // throttle a bit to ensure we aren't wasting CPU time
+                await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken)
+                    .ConfigureAwait(false);
+            }
         }
     }
 


### PR DESCRIPTION
* When there are no events to receive, wait for half a second before checking again. This throttling should avoid the busy wait and prevent excessive CPU usage. Fixes #9.
* When calculating the session replay delay, make sure UTC is accounted for correctly.