### PR TITLE
Prefer to use the Kitty graphics protocol over iTerm

### DIFF
--- a/UndercutF1.Console/Display/DriverTrackerDisplay.cs
+++ b/UndercutF1.Console/Display/DriverTrackerDisplay.cs
@@ -384,14 +384,14 @@ public class DriverTrackerDisplay(
         var imageData = surface.Snapshot().Encode();
         var base64 = Convert.ToBase64String(imageData.AsSpan());
 
-        if (terminalInfo.IsITerm2ProtocolSupported.Value)
-        {
-            return TerminalGraphics.ITerm2GraphicsSequence(windowHeight, windowWidth, base64);
-        }
-        else if (terminalInfo.IsKittyProtocolSupported.Value)
+        if (terminalInfo.IsKittyProtocolSupported.Value)
         {
             return TerminalGraphics.KittyGraphicsSequenceDelete()
                 + TerminalGraphics.KittyGraphicsSequence(windowHeight, windowWidth, base64);
+        }
+        else if (terminalInfo.IsITerm2ProtocolSupported.Value)
+        {
+            return TerminalGraphics.ITerm2GraphicsSequence(windowHeight, windowWidth, base64);
         }
 
         return "Unexpected error, shouldn't have got here. Please report!";

--- a/UndercutF1.Console/Display/TimingHistoryDisplay.cs
+++ b/UndercutF1.Console/Display/TimingHistoryDisplay.cs
@@ -329,14 +329,14 @@ public class TimingHistoryDisplay(
         var imageData = surface.Snapshot().Encode();
         var base64 = Convert.ToBase64String(imageData.AsSpan());
 
-        if (terminalInfo.IsITerm2ProtocolSupported.Value)
-        {
-            return TerminalGraphics.ITerm2GraphicsSequence(heightCells, widthCells, base64);
-        }
-        else if (terminalInfo.IsKittyProtocolSupported.Value)
+        if (terminalInfo.IsKittyProtocolSupported.Value)
         {
             return TerminalGraphics.KittyGraphicsSequenceDelete()
                 + TerminalGraphics.KittyGraphicsSequence(heightCells, widthCells, base64);
+        }
+        else if (terminalInfo.IsITerm2ProtocolSupported.Value)
+        {
+            return TerminalGraphics.ITerm2GraphicsSequence(heightCells, widthCells, base64);
         }
 
         return "Unexpected error, shouldn't have got here. Please report!";


### PR DESCRIPTION
When both protocols are available, use Kitty instead of iTerm. Should fix #8.

Validated graphics do display in Kitty, Ghostty, and iTerm on Mac.