### PR TITLE
Publish a docker image as an alternative way to run the app

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,26 +13,26 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Publish
-      run: dotnet publish --no-restore /p:PublicRelease=true
-    - name: Pack
-      run: dotnet pack --no-build /p:PublicRelease=true
-    - name: Push Packages
-      if: ${{ github.event_name == 'release'}}
-      run: dotnet nuget push "**/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-  
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Publish
+        run: dotnet publish --no-restore /p:PublicRelease=true
+      - name: Pack
+        run: dotnet pack --no-build /p:PublicRelease=true
+      - name: Push Packages
+        if: ${{ github.event_name == 'release'}}
+        run: dotnet nuget push "**/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+
   build-executable:
     runs-on: ubuntu-latest
-  
+
     permissions:
       contents: write
 
@@ -41,49 +41,76 @@ jobs:
         target: [osx-arm64, linux-x64, linux-arm64, win-x64]
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.0.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
 
-    - name: Restore dependencies
-      run: dotnet restore
+      - name: Restore dependencies
+        run: dotnet restore
 
-    - name: Create ${{ matrix.target }} Package
-      run: dotnet publish -r ${{ matrix.target }} --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:IncludeAllContentForSelfExtract=true -p:PublicRelease=true UndercutF1.Console/UndercutF1.Console.csproj -o ${{ matrix.target }}-output
-    
-    - name: Download codesign certificate
-      if: contains(matrix.target, 'osx')
-      env:
-        MAC_CODESIGN_CERT: ${{ secrets.MAC_CODESIGN_CERT }}
-      run: |
-        echo $MAC_CODESIGN_CERT | base64 --decode > certificate.p12
+      - name: Create ${{ matrix.target }} Package
+        run: dotnet publish -r ${{ matrix.target }} --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:IncludeAllContentForSelfExtract=true -p:PublicRelease=true UndercutF1.Console/UndercutF1.Console.csproj -o ${{ matrix.target }}-output
 
-    - name: Sign Executable
-      uses: indygreg/apple-code-sign-action@v1
-      if: contains(matrix.target, 'osx')
-      with:
-        input_path: ${{ matrix.target }}-output/undercutf1
-        p12_file: certificate.p12
-        p12_password: ${{ secrets.MAC_CODESIGN_PASSWORD }}
+      - name: Download codesign certificate
+        if: contains(matrix.target, 'osx')
+        env:
+          MAC_CODESIGN_CERT: ${{ secrets.MAC_CODESIGN_CERT }}
+        run: |
+          echo $MAC_CODESIGN_CERT | base64 --decode > certificate.p12
 
-    - name: Upload ${{ matrix.target }} to Release
-      uses: svenstaro/upload-release-action@v2
-      if: ${{ github.event_name == 'release'}}
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ matrix.target }}-output/${{ contains(matrix.target, 'win') && 'undercutf1.exe'  || 'undercutf1'}}
-        asset_name: undercutf1-${{ matrix.target }}${{ contains(matrix.target, 'win') && '.exe'  || ''}}
-        tag: ${{ github.ref }}
+      - name: Sign Executable
+        uses: indygreg/apple-code-sign-action@v1
+        if: contains(matrix.target, 'osx')
+        with:
+          input_path: ${{ matrix.target }}-output/undercutf1
+          p12_file: certificate.p12
+          p12_password: ${{ secrets.MAC_CODESIGN_PASSWORD }}
 
-    - name: Upload ${{ matrix.target }} to Pull Request
-      uses: actions/upload-artifact@v4
-      if: ${{ github.event_name == 'pull_request'}}
-      with:
-        name: undercutf1-${{ matrix.target }}${{ contains(matrix.target, 'win') && '.exe'  || ''}}
-        path: ${{ matrix.target }}-output/${{ contains(matrix.target, 'win') && 'undercutf1.exe'  || 'undercutf1'}}
-        overwrite: true
+      - name: Upload ${{ matrix.target }} to Release
+        uses: svenstaro/upload-release-action@v2
+        if: ${{ github.event_name == 'release'}}
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ matrix.target }}-output/${{ contains(matrix.target, 'win') && 'undercutf1.exe'  || 'undercutf1'}}
+          asset_name: undercutf1-${{ matrix.target }}${{ contains(matrix.target, 'win') && '.exe'  || ''}}
+          tag: ${{ github.ref }}
+
+      - name: Upload ${{ matrix.target }} to Pull Request
+        uses: actions/upload-artifact@v4
+        if: ${{ github.event_name == 'pull_request'}}
+        with:
+          name: undercutf1-${{ matrix.target }}${{ contains(matrix.target, 'win') && '.exe'  || ''}}
+          path: ${{ matrix.target }}-output/${{ contains(matrix.target, 'win') && 'undercutf1.exe'  || 'undercutf1'}}
+          overwrite: true
+
+  build-docker-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish for Release
+        if: ${{ github.event_name == 'release'}}
+        run: dotnet publish -r linux-x64 /p:PublicRelease=true /p:ContainerRegistry=docker.io /t:PublishContainer UndercutF1.Console/UndercutF1.Console.csproj
+
+      - name: Publish for PR
+        if: ${{ github.event_name == 'pull_request'}}
+        run: dotnet publish -r linux-x64 /p:ContainerImageTags=pull_request /p:ContainerRegistry=docker.io /t:PublishContainer UndercutF1.Console/UndercutF1.Console.csproj

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Feature Highlights:
   - [Installation](#installation)
     - [Install and run as a dotnet tool](#install-and-run-as-a-dotnet-tool)
     - [Install and run the standalone executable](#install-and-run-the-standalone-executable)
+  - [Install and run using the docker image](#install-and-run-using-the-docker-image)
     - [Run directly from Source](#run-directly-from-source)
   - [Start Timing for a Live Session](#start-timing-for-a-live-session)
   - [Start Timing for a Pre-recorded Session](#start-timing-for-a-pre-recorded-session)
@@ -147,6 +148,22 @@ curl https://github.com/JustAman62/undercut-f1/releases/latest/download/undercut
 ./undercutf1
 ```
 
+### Install and run using the docker image
+
+Docker images are pushed to Dockerhub containing the executable.
+The image expects a volume to be mounted at `/data` to store/read session recordings.
+If this is not provided, the application will only work for live sessions and you'll lose recorded data.
+
+If provided, the directory you are mapping must already exist, as the docker image will not have the required permissions to create it for you.
+
+```sh
+docker run -it -v $HOME/undercut-f1/data:/data justaman62/undercutf1
+
+# Arguments can still be passed to the executable as normal
+# for example:
+docker run -it -v $HOME/undercut-f1/data:/data justaman62/undercutf1 import 2025
+```
+
 #### Run directly from Source
 
 ```sh
@@ -156,6 +173,9 @@ cd undercut-f1
 
 # Run the console project with `dotnet run`
 dotnet run --project UndercutF1.Console/UndercutF1.Console.csproj
+
+# Arguments can be provided after the -- argument, for example
+dotnet run --project UndercutF1.Console/UndercutF1.Console.csproj -- import 2025
 ```
 
 By default, data will be saved and read from the `~/undercut-f1` directory. See [Configuration](#configuration) for information on how to configure this.
@@ -221,7 +241,7 @@ UndercutF1 can be configured using either a simple `config.json` file, through t
 | --------------- | ------------------ | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `dataDirectory` | `--data-directory` | `UNDERCUTF1_DATADIRECTORY` | The directory in which JSON timing data is read or written from.                                                                                   |
 | `verbose`       | `-v\|--verbose`    | `UNDERCUTF1_VERBOSE`       | Whether verbose logging should be enabled. Default: `false`. Values: `true` or `false`.                                                            |
-| `apiEnabled`    | `--with-api`       | `UNDERCUTF1_APIENABLED`    | Whether the app should expose an API at <http://localhost:61937>. Default: `false`. Values: `true` or `false`.                                       |
+| `apiEnabled`    | `--with-api`       | `UNDERCUTF1_APIENABLED`    | Whether the app should expose an API at <http://localhost:61937>. Default: `false`. Values: `true` or `false`.                                     |
 | `notify`        | `--notify`         | `UNDERCUTF1_NOTIFY`        | Whether the app should sent audible BELs to your terminal when new race control messages are received. Default: `true`. Values: `true` or `false`. |
 
 ## Logging

--- a/UndercutF1.Console/UndercutF1.Console.csproj
+++ b/UndercutF1.Console/UndercutF1.Console.csproj
@@ -11,6 +11,7 @@
     <PackageTags>formula1;formula-1;f1;livetiming;timing;tui;terminal-ui</PackageTags>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <ContainerRepository>justaman62/undercutf1</ContainerRepository>
   </PropertyGroup>
 
   <ItemGroup>
@@ -48,5 +49,15 @@
   <ItemGroup>
     <None Include="../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ContainerEnvironmentVariable Include="UNDERCUTF1_DATADIRECTORY" Value="/data" />
+  </ItemGroup>
+
+  <Target Name="SetContainerTagsBasedOnVersion" DependsOnTargets="GetBuildVersion" BeforeTargets="CoreCompile">
+    <PropertyGroup Condition="'$(ContainerImageTags)' == ''">
+      <ContainerImageTags>$(Version);latest</ContainerImageTags>
+    </PropertyGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
Docker images are now pushed to DockerHub under the `justaman62/undercutf1` repository. Images are pushed with the `latest` tag, and a specific version tag.