### PR TITLE
Remove input handling for ^N and ^M 

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ F1 provides static timing data files for already completed sessions. This data c
 
 #### Managing Delay
 
-All session data, whether live or pre-recorded, is sent to a `Channel` that acts as a delayed-queue. After a short delay, data points are pulled from the queue and processed, leading to updates on the timing screens. The amount of this delay can be changed with the <kbd>M</kbd>/<kbd>N</kbd> `Delay` actions whilst on the timing screens. Hold <kbd>⇧ Shift</kbd> to change the delay by 30 seconds instead of 5, and hold the <kbd>^ Control</kbd> key to change by 1 second. When using `undercutf1` during a live session, you may wish to increase this delay to around ~50 seconds (actual number may vary) to match with the broadcast delay and avoid being spoiled about upcoming action.
+All session data, whether live or pre-recorded, is sent to a `Channel` that acts as a delayed-queue. After a short delay, data points are pulled from the queue and processed, leading to updates on the timing screens. The amount of this delay can be changed with the <kbd>M</kbd>/<kbd>N</kbd> `Delay` actions whilst on the timing screens. Hold <kbd>⇧ Shift</kbd> to change the delay by 30 seconds instead of 5. Use the <kbd>,</kbd>/<kbd>.</kbd> keys to change by 1 second. When using `undercutf1` during a live session, you may wish to increase this delay to around ~50 seconds (actual number may vary) to match with the broadcast delay and avoid being spoiled about upcoming action.
 
 Simulated sessions start with a calculated delay equal to the amount of time between the start of the actual session and now. This means you can decrease the delay with the <kbd>N</kbd> `Delay` action to fast-forward through the session.
 

--- a/UndercutF1.Console/ConsoleLoop.cs
+++ b/UndercutF1.Console/ConsoleLoop.cs
@@ -328,17 +328,6 @@ public class ConsoleLoop(
             case [ESC, ..]:
                 logger.LogInformation("Unknown esc sequence: {Seq}", string.Join('|', bytes[1..]));
                 break;
-            case [13, ..]: // ^M key press
-                keyChar = 'n';
-                consoleKey = ConsoleKey.M;
-                modifiers = ConsoleModifiers.Control;
-                return true;
-            case [14, ..]: // ^N key press
-                keyChar = 'm';
-                consoleKey = ConsoleKey.N;
-                modifiers = ConsoleModifiers.Control;
-                return true;
-
             case [var key, ..]: // Just a normal key press
                 keyChar = (char)key;
                 consoleKey = (ConsoleKey)char.ToUpperInvariant(keyChar);

--- a/UndercutF1.Console/Display/MainDisplay.cs
+++ b/UndercutF1.Console/Display/MainDisplay.cs
@@ -25,8 +25,8 @@ public class MainDisplay() : IDisplay
 
             Once a session is started, navigate to the Timing Tower using [bold]T[/]
             Then use the Arrow Keys [bold]◄[/]/[bold]►[/] to switch between timing pages.
-            Use [bold]N[/]/[bold]M[/] to adjust the stream delay, and [bold]▲[/]/[bold]▼[/] keys to use the cursor.
-            Press Shift with these keys to adjust by a higher amount, and Control to adjust by a smaller amount.
+            Use [bold]N[/]/[bold]M[/]/[bold],[/]/[bold].[/] to adjust the stream delay, and [bold]▲[/]/[bold]▼[/] keys to use the cursor.
+            Press Shift with these keys to adjust by a higher amount.
 
             You can download old session data from Formula 1 by running:
             > undercutf1 import

--- a/UndercutF1.Console/Input/DelayInputHandler.cs
+++ b/UndercutF1.Console/Input/DelayInputHandler.cs
@@ -16,7 +16,10 @@ public class DelayInputHandler(IDateTimeProvider dateTimeProvider) : IInputHandl
             Screen.TyreStints,
         ];
 
-    public ConsoleKey[] Keys => [ConsoleKey.N, ConsoleKey.M];
+    public ConsoleKey[] DisplayKeys => [ConsoleKey.N, ConsoleKey.M];
+    // PrintScreen keycode = 44 (actually comma)
+    // Delete keycode = 46 (actually period)
+    public ConsoleKey[] Keys => [ConsoleKey.N, ConsoleKey.M, ConsoleKey.PrintScreen, ConsoleKey.Delete];
 
     public string Description => "Delay";
 
@@ -29,11 +32,17 @@ public class DelayInputHandler(IDateTimeProvider dateTimeProvider) : IInputHandl
     {
         switch (consoleKeyInfo.Key)
         {
+            case ConsoleKey.N:
+                UpdateDelay(-1, consoleKeyInfo.Modifiers);
+                break;
             case ConsoleKey.M:
                 UpdateDelay(1, consoleKeyInfo.Modifiers);
                 break;
-            case ConsoleKey.N:
-                UpdateDelay(-1, consoleKeyInfo.Modifiers);
+            case ConsoleKey.PrintScreen:
+                UpdateDelay(-1, ConsoleModifiers.Control);
+                break;
+            case ConsoleKey.Delete:
+                UpdateDelay(1, ConsoleModifiers.Control);
                 break;
         }
 


### PR DESCRIPTION
^M keypress conflicts with the enter keycode. Single second delay changes is now does by comma and period instead.