### PR TITLE
Transcription improvements

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,7 +42,11 @@
     <PackageVersion Include="Vezel.Cathode" Version="0.14.17" />
     <PackageVersion Include="Vezel.Cathode.Extensions" Version="0.14.17" />
     <PackageVersion Include="Whisper.net" Version="1.8.1" />
-    <PackageVersion Include="Whisper.net.AllRuntimes" Version="1.8.1" />
+    <PackageVersion Include="Whisper.net.Runtime" Version="1.8.1" />
+    <PackageVersion Include="Whisper.net.Runtime.Cuda" Version="1.8.1" />
+    <PackageVersion Include="Whisper.net.Runtime.OpenVino" Version="1.8.1" />
+    <PackageVersion Include="Whisper.net.Runtime.NoAvx" Version="1.8.1" />
+    <PackageVersion Include="Whisper.net.Runtime.Vulkan" Version="1.8.1" />
     <PackageVersion Include="xunit" Version="2.5.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,8 +41,8 @@
     <PackageVersion Include="TextCopy" Version="6.2.1" />
     <PackageVersion Include="Vezel.Cathode" Version="0.14.17" />
     <PackageVersion Include="Vezel.Cathode.Extensions" Version="0.14.17" />
-    <PackageVersion Include="Whisper.net" Version="1.5.0" />
-    <PackageVersion Include="Whisper.net.Runtime" Version="1.5.0" />
+    <PackageVersion Include="Whisper.net" Version="1.8.1" />
+    <PackageVersion Include="Whisper.net.AllRuntimes" Version="1.8.1" />
     <PackageVersion Include="xunit" Version="2.5.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
   </ItemGroup>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
 
-# Required for SkiaSharp
-RUN apt-get update && apt-get install libfontconfig -y
+# libfontconfig required for SkiaSharp
+# ffmpeg libgdiplus required for ffmpeg
+RUN apt-get update && apt-get install libfontconfig ffmpeg libgdiplus -y
 
 
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS build

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Feature Highlights:
   - [Installation](#installation)
     - [Install and run as a dotnet tool](#install-and-run-as-a-dotnet-tool)
     - [Install and run the standalone executable](#install-and-run-the-standalone-executable)
-    - [Install and run using the docker image](#install-and-run-using-the-docker-image)
+    - [Run using the docker image](#run-using-the-docker-image)
       - [Known Issues with Docker](#known-issues-with-docker)
     - [Run directly from Source](#run-directly-from-source)
   - [Start Timing for a Live Session](#start-timing-for-a-live-session)
@@ -153,7 +153,7 @@ curl https://github.com/JustAman62/undercut-f1/releases/latest/download/undercut
 ./undercutf1
 ```
 
-#### Install and run using the docker image
+#### Run using the docker image
 
 Docker images are pushed to Dockerhub containing the executable.
 The image expects a volume to be mounted at `/data` to store/read session recordings.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Feature Highlights:
     - [Install and run as a dotnet tool](#install-and-run-as-a-dotnet-tool)
     - [Install and run the standalone executable](#install-and-run-the-standalone-executable)
     - [Install and run using the docker image](#install-and-run-using-the-docker-image)
+      - [Known Issues with Docker](#known-issues-with-docker)
     - [Run directly from Source](#run-directly-from-source)
   - [Start Timing for a Live Session](#start-timing-for-a-live-session)
   - [Start Timing for a Pre-recorded Session](#start-timing-for-a-pre-recorded-session)
@@ -166,6 +167,10 @@ docker run -it -e TERM_PROGRAM -v $HOME/undercut-f1/data:/data justaman62/underc
 # for example:
 docker run -it -v $HOME/undercut-f1/data:/data justaman62/undercutf1 import 2025
 ```
+
+##### Known Issues with Docker
+
+- Audio playback of Team Radio may not work when using Docker. This is due to difficulties in using and routing the alsa audio, which I haven't managed to figure out yet.
 
 #### Run directly from Source
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Charts on the right display how Gap to Leader and Lap Time for all selected driv
 
 Listen to team radio clips from anytime in the session, and use a local ML model (Whisper) to transcribe the audio on demand. Transcription accuracy is fairly low, depending on the that days audio quality and driver. Suggestions welcome for improving this!
 
+Audio playback prerequisites:
+
+- If on Linux, make sure you have `aplay` and `mpg123` installed. See [the NetCoreAudio Prerequisites for more details](https://github.com/mobiletechtracker/NetCoreAudio?tab=readme-ov-file#prerequisites)
+
 ![Listen to and Transcribe Team Radio](docs/screenshots/team-radio.png)
 
 ## Getting Started with `undercutf1`

--- a/UndercutF1.Console/CommandHandler.Root.cs
+++ b/UndercutF1.Console/CommandHandler.Root.cs
@@ -72,6 +72,27 @@ public static partial class CommandHandler
 
         app.Logger.LogDebug("Options: {Options}", options);
 
+        Whisper.net.Logger.LogProvider.AddLogger(
+            (level, msg) =>
+            {
+                switch (level)
+                {
+                    case Whisper.net.Logger.WhisperLogLevel.Error:
+                        app.Logger.LogError("Whisper: {Message}", msg);
+                        break;
+                    case Whisper.net.Logger.WhisperLogLevel.Warning:
+                        app.Logger.LogWarning("Whisper: {Message}", msg);
+                        break;
+                    case Whisper.net.Logger.WhisperLogLevel.Debug:
+                        app.Logger.LogDebug("Whisper: {Message}", msg);
+                        break;
+                    default:
+                        app.Logger.LogDebug("Whisper {Level}: {Message}", level, msg);
+                        break;
+                }
+            }
+        );
+
         await app.RunAsync();
     }
 }

--- a/UndercutF1.Console/Display/DownloadTranscriptionModelDisplay.cs
+++ b/UndercutF1.Console/Display/DownloadTranscriptionModelDisplay.cs
@@ -1,0 +1,27 @@
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using UndercutF1.Data;
+
+namespace UndercutF1.Console;
+
+public class DownloadTranscriptionModelDisplay(ITranscriptionProvider transcriptionProvider)
+    : IDisplay
+{
+    public Screen Screen => Screen.DownloadTranscriptionModel;
+
+    public Task<IRenderable> GetContentAsync()
+    {
+        var text = $"""
+            Transcriptions require a Whisper ML model to be downloaded.
+            We can download this model for you, and will store it at {transcriptionProvider.ModelPath}
+            This path is set as a child of the DataDirectory configuration option.
+            The model is around 150MB.
+
+            Please press [bold]⏎ Enter[/] if you're happy for this model to be downloaded, or press [bold]Esc[/] to abort.
+
+            Once downloaded, you'll be sent back to the Team Radio list so you can try to transcribe again.
+            """;
+
+        return Task.FromResult<IRenderable>(new Markup(text));
+    }
+}

--- a/UndercutF1.Console/Display/TeamRadioDisplay.cs
+++ b/UndercutF1.Console/Display/TeamRadioDisplay.cs
@@ -56,14 +56,21 @@ public sealed class TeamRadioDisplay(
         };
     }
 
-    private IRenderable GetSelectedTranscription()
+    private Panel GetSelectedTranscription()
     {
         var selected = teamRadio.Ordered.ElementAtOrDefault(state.CursorOffset);
 
-        var text = string.IsNullOrWhiteSpace(selected.Value?.Transcription)
-            ? new Text("No transcription loaded. Press [T] to load.")
-            : new Text(selected.Value.Transcription);
+        var text = $"""
+            {selected.Value?.Transcription ?? "No transcription loaded. Press [T] to load."}
 
-        return new Panel(text) { Expand = true, Header = new PanelHeader("Transcription") };
+            Team Radio File Path: {selected.Value?.DownloadedFilePath
+                ?? "Play/Transcribe to download"}
+            """;
+
+        return new Panel(new Text(text))
+        {
+            Expand = true,
+            Header = new PanelHeader("Transcription"),
+        };
     }
 }

--- a/UndercutF1.Console/Input/DelayInputHandler.cs
+++ b/UndercutF1.Console/Input/DelayInputHandler.cs
@@ -17,9 +17,11 @@ public class DelayInputHandler(IDateTimeProvider dateTimeProvider) : IInputHandl
         ];
 
     public ConsoleKey[] DisplayKeys => [ConsoleKey.N, ConsoleKey.M];
+
     // PrintScreen keycode = 44 (actually comma)
     // Delete keycode = 46 (actually period)
-    public ConsoleKey[] Keys => [ConsoleKey.N, ConsoleKey.M, ConsoleKey.PrintScreen, ConsoleKey.Delete];
+    public ConsoleKey[] Keys =>
+        [ConsoleKey.N, ConsoleKey.M, ConsoleKey.PrintScreen, ConsoleKey.Delete];
 
     public string Description => "Delay";
 

--- a/UndercutF1.Console/Input/DownloadTranscriptionModelInputHandler.cs
+++ b/UndercutF1.Console/Input/DownloadTranscriptionModelInputHandler.cs
@@ -1,0 +1,64 @@
+using UndercutF1.Data;
+
+namespace UndercutF1.Console;
+
+public sealed class DownloadTranscriptionModelInputHandler(
+    ITranscriptionProvider transcriptionProvider,
+    State state,
+    ILogger<DownloadTranscriptionModelInputHandler> logger
+) : IInputHandler
+{
+    public bool IsEnabled => true;
+
+    public Screen[] ApplicableScreens => [Screen.DownloadTranscriptionModel];
+
+    public ConsoleKey[] Keys => [ConsoleKey.Enter];
+
+    public string Description =>
+        _task switch
+        {
+            { IsCompleted: false } => "Downloading...",
+            null => "Download",
+            _ => "Error, Retry?",
+        };
+
+    public int Sort => 40;
+
+    private Task? _task = null;
+
+    public Task ExecuteAsync(
+        ConsoleKeyInfo consoleKeyInfo,
+        CancellationToken cancellationToken = default
+    )
+    {
+        switch (_task)
+        {
+            case { IsCompleted: false }:
+                logger.LogInformation(
+                    "Asked to download transcription model, but already downloading"
+                );
+                break;
+            default:
+                _task = Task.Run(DownloadModel, cancellationToken);
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task DownloadModel()
+    {
+        try
+        {
+            await transcriptionProvider.EnsureModelDownloaded();
+            logger.LogInformation("Transcription model downloaded");
+
+            state.CurrentScreen = Screen.TeamRadio;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to download transcription model");
+            throw;
+        }
+    }
+}

--- a/UndercutF1.Console/Input/EscapeInputHandler.cs
+++ b/UndercutF1.Console/Input/EscapeInputHandler.cs
@@ -32,6 +32,7 @@ public class EscapeInputHandler(State state) : IInputHandler
         {
             Screen.Main => Screen.Shutdown,
             Screen.StartSimulatedSession => Screen.ManageSession,
+            Screen.DownloadTranscriptionModel => Screen.TeamRadio,
             _ => Screen.Main,
         };
 

--- a/UndercutF1.Console/Input/TranscribeTeamRadioInputHandler.cs
+++ b/UndercutF1.Console/Input/TranscribeTeamRadioInputHandler.cs
@@ -6,6 +6,7 @@ namespace UndercutF1.Console;
 public sealed class TranscribeTeamRadioInputHandler(
     State state,
     TeamRadioProcessor teamRadio,
+    ITranscriptionProvider transcriptionProvider,
     ILogger<TranscribeTeamRadioInputHandler> logger
 ) : IInputHandler
 {
@@ -32,6 +33,12 @@ public sealed class TranscribeTeamRadioInputHandler(
         CancellationToken cancellationToken = default
     )
     {
+        if (!transcriptionProvider.IsModelDownloaded)
+        {
+            state.CurrentScreen = Screen.DownloadTranscriptionModel;
+            return Task.CompletedTask;
+        }
+
         switch (_task)
         {
             case { IsCompleted: false }:

--- a/UndercutF1.Console/Input/TranscribeTeamRadioInputHandler.cs
+++ b/UndercutF1.Console/Input/TranscribeTeamRadioInputHandler.cs
@@ -38,7 +38,7 @@ public sealed class TranscribeTeamRadioInputHandler(
                 logger.LogInformation("Asked to start transcribing, but already working");
                 break;
             default:
-                _task = Task.Run(() => TranscribeAsync(state.CursorOffset));
+                _task = Task.Run(() => TranscribeAsync(state.CursorOffset), cancellationToken);
                 break;
         }
         return Task.CompletedTask;
@@ -69,6 +69,7 @@ public sealed class TranscribeTeamRadioInputHandler(
                 Team Radio File Path: {radio.Value.DownloadedFilePath}
                 """;
             logger.LogError(ex, text);
+            radio.Value.Transcription = text;
         }
     }
 }

--- a/UndercutF1.Console/Screen.cs
+++ b/UndercutF1.Console/Screen.cs
@@ -15,4 +15,5 @@ public enum Screen
     TeamRadio,
     TyreStints,
     DebugData,
+    DownloadTranscriptionModel,
 }

--- a/UndercutF1.Data/Interfaces/ITranscriptionProvider.cs
+++ b/UndercutF1.Data/Interfaces/ITranscriptionProvider.cs
@@ -2,8 +2,13 @@ namespace UndercutF1.Data;
 
 public interface ITranscriptionProvider
 {
+    string ModelPath { get; }
+    bool IsModelDownloaded { get; }
+
     Task<string> TranscribeFromFileAsync(
         string filePath,
         CancellationToken cancellationToken = default
     );
+
+    Task EnsureModelDownloaded();
 }

--- a/UndercutF1.Data/TranscriptionProvider.cs
+++ b/UndercutF1.Data/TranscriptionProvider.cs
@@ -62,7 +62,10 @@ public class TranscriptionProvider(
                 ModelPath
             );
             Directory.CreateDirectory(Directory.GetParent(ModelPath)!.FullName);
-            using var modelStream = await WhisperGgmlDownloader.GetGgmlModelAsync(GgmlType.BaseEn);
+            using var modelStream = await WhisperGgmlDownloader.Default.GetGgmlModelAsync(
+                GgmlType.BaseEn
+            );
+            ;
             using var fileWriter = File.OpenWrite(ModelPath);
             await modelStream.CopyToAsync(fileWriter);
         }

--- a/UndercutF1.Data/TranscriptionProvider.cs
+++ b/UndercutF1.Data/TranscriptionProvider.cs
@@ -15,14 +15,16 @@ public class TranscriptionProvider(
     ILogger<TranscriptionProvider> logger
 ) : ITranscriptionProvider
 {
-    private string ModelPath => Path.Join(options.Value.DataDirectory, "models/ggml-base.bin");
+    public string ModelPath => Path.Join(options.Value.DataDirectory, "models/ggml-base.bin");
+
+    public bool IsModelDownloaded => File.Exists(ModelPath);
 
     public async Task<string> TranscribeFromFileAsync(
         string filePath,
         CancellationToken cancellationToken = default
     )
     {
-        await CheckModelInitialised().ConfigureAwait(false);
+        await EnsureModelDownloaded().ConfigureAwait(false);
         using var whisperFactory = WhisperFactory.FromPath(ModelPath);
 
         using var processor = whisperFactory.CreateBuilder().WithLanguage("auto").Build();
@@ -51,11 +53,14 @@ public class TranscriptionProvider(
         return text;
     }
 
-    private async Task CheckModelInitialised()
+    public async Task EnsureModelDownloaded()
     {
-        if (!File.Exists(ModelPath))
+        if (!IsModelDownloaded)
         {
-            logger.LogInformation("Whisper model not found at {}, so downloading it.", ModelPath);
+            logger.LogInformation(
+                "Whisper model not found at {ModelPath}, so downloading it.",
+                ModelPath
+            );
             Directory.CreateDirectory(Directory.GetParent(ModelPath)!.FullName);
             using var modelStream = await WhisperGgmlDownloader.GetGgmlModelAsync(GgmlType.BaseEn);
             using var fileWriter = File.OpenWrite(ModelPath);
@@ -63,7 +68,7 @@ public class TranscriptionProvider(
         }
         else
         {
-            logger.LogDebug("Whisper model already exists at {}.", ModelPath);
+            logger.LogDebug("Whisper model already exists at {ModelPAth}.", ModelPath);
         }
     }
 }

--- a/UndercutF1.Data/UndercutF1.Data.csproj
+++ b/UndercutF1.Data/UndercutF1.Data.csproj
@@ -18,7 +18,11 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Whisper.net" />
-    <PackageReference Include="Whisper.net.AllRuntimes" />
+    <PackageReference Include="Whisper.net.Runtime" />
+    <PackageReference Include="Whisper.net.Runtime.Cuda" />
+    <PackageReference Include="Whisper.net.Runtime.OpenVino" />
+    <PackageReference Include="Whisper.net.Runtime.NoAvx" />
+    <PackageReference Include="Whisper.net.Runtime.Vulkan" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UndercutF1.Data/UndercutF1.Data.csproj
+++ b/UndercutF1.Data/UndercutF1.Data.csproj
@@ -18,8 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Whisper.net" />
-    <!-- TODO: Consider conditionally using Whisper.net.Runtime.CoreML for improved Mac performance -->
-    <PackageReference Include="Whisper.net.Runtime" />
+    <PackageReference Include="Whisper.net.AllRuntimes" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Have a confirmation page when you try to transcribe but don't have the Whisper model downloaded. This should help to ensure nobody is surprised when a 150mb file is downloaded.
- Upgrade Whisper.net and use package that supports all possible runtimes. This should mean that when available the GPU will be used for inference during transcription.
- Display the file location of downloaded team radio files
- Update docker image to include ffmpeg to ensure transcription works correctly.

Relates to #25