### PR TITLE
Reduce executable size

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,10 +43,6 @@
     <PackageVersion Include="Vezel.Cathode.Extensions" Version="0.14.17" />
     <PackageVersion Include="Whisper.net" Version="1.8.1" />
     <PackageVersion Include="Whisper.net.Runtime" Version="1.8.1" />
-    <PackageVersion Include="Whisper.net.Runtime.Cuda" Version="1.8.1" />
-    <PackageVersion Include="Whisper.net.Runtime.OpenVino" Version="1.8.1" />
-    <PackageVersion Include="Whisper.net.Runtime.NoAvx" Version="1.8.1" />
-    <PackageVersion Include="Whisper.net.Runtime.Vulkan" Version="1.8.1" />
     <PackageVersion Include="xunit" Version="2.5.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
   </ItemGroup>

--- a/UndercutF1.Console/UndercutF1.Console.csproj
+++ b/UndercutF1.Console/UndercutF1.Console.csproj
@@ -11,6 +11,7 @@
     <PackageTags>formula1;formula-1;f1;livetiming;timing;tui;terminal-ui</PackageTags>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UndercutF1.Data/UndercutF1.Data.csproj
+++ b/UndercutF1.Data/UndercutF1.Data.csproj
@@ -19,10 +19,6 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Whisper.net" />
     <PackageReference Include="Whisper.net.Runtime" />
-    <PackageReference Include="Whisper.net.Runtime.Cuda" />
-    <PackageReference Include="Whisper.net.Runtime.OpenVino" />
-    <PackageReference Include="Whisper.net.Runtime.NoAvx" />
-    <PackageReference Include="Whisper.net.Runtime.Vulkan" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Referencing all the Whisper runtimes caused excessive executable bloat
* Compress the executable when publishing. This might lead to slightly slower startup times, but personally isn't very noticeable.