### PR TITLE
Use standard data/log directories, expose configuration information in TUI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 **/.classpath
 **/.dockerignore
 **/.env
-**/.git
 **/.gitignore
 **/.project
 **/.settings

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -120,6 +120,7 @@ jobs:
         if: ${{ github.event_name == 'release'}}
         uses: docker/build-push-action@v6
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: justaman62/undercutf1:latest,justaman62/undercutf1:${{ steps.nbgv.outputs.SemVer2 }}
@@ -128,6 +129,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request'}}
         uses: docker/build-push-action@v6
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: justaman62/undercutf1:${{ steps.nbgv.outputs.SemVer2 }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <NBGV_ThisAssemblyIncludesPackageVersion>true</NBGV_ThisAssemblyIncludesPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,17 +14,17 @@
     <PackageVersion Include="Microcharts" Version="0.9.5.9" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="7.0.7" />
     <PackageVersion Include="Microsoft.AspNet.SignalR.Client" Version="2.4.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageVersion Include="NAudio" Version="2.2.1" />
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageVersion Include="NetCoreAudio" Version="2.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.0.0" />
     <PackageVersion Include="Serilog" Version="4.0.0" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install libfontconfig ffmpeg libgdiplus -y
 
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
+COPY .git .git
 COPY ["Directory.Build.props", "Directory.Build.props"]
 COPY ["Directory.Packages.props", "Directory.Packages.props"]
 COPY ["UndercutF1.Data/UndercutF1.Data.csproj", "UndercutF1.Data/"]
@@ -22,5 +23,6 @@ WORKDIR /app
 COPY --from=build /app/publish .
 
 ENV UNDERCUTF1_DATADIRECTORY=/data
+ENV UNDERCUTF1_LOGDIRECTORY=/logs
 
 ENTRYPOINT ["dotnet", "undercutf1.dll"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Feature Highlights:
     - [Managing Delay](#managing-delay)
     - [Using the Cursor](#using-the-cursor)
 - [Configuration](#configuration)
+  - [Default Directories](#default-directories)
 - [Logging](#logging)
 - [Live Timing Data Source](#live-timing-data-source)
 - [Data Recording and Replay](#data-recording-and-replay)
@@ -190,8 +191,6 @@ dotnet run --project UndercutF1.Console/UndercutF1.Console.csproj
 dotnet run --project UndercutF1.Console/UndercutF1.Console.csproj -- import 2025
 ```
 
-By default, data will be saved and read from the `~/undercut-f1` directory. See [Configuration](#configuration) for information on how to configure this.
-
 ### Start Timing for a Live Session
 
 1. Start `undercutf1` as described above
@@ -199,13 +198,13 @@ By default, data will be saved and read from the `~/undercut-f1` directory. See 
 3. Start a Live Session with the <kbd>L</kbd> `Start Live Session` action.
 4. Switch to the Timing Tower screen with the <kbd>T</kbd> `Timing Tower` action
 
-During the session, streamed timing data will be written to `~/undercut-f1/data/<session-name>`. This will allow for [future replays](#start-timing-for-a-pre-recorded-session) of this recorded data.
+During the session, streamed timing data will be written to [the configured data directory](#default-directories). This will allow for [future replays](#start-timing-for-a-pre-recorded-session) of this recorded data.
 
 ### Start Timing for a Pre-recorded Session
 
-Data for pre-recorded sessions should be stored in the `~/undercut-f1/data/<session-name>` directory. Sample data can be found in this repos [Sample Data](/Sample%20Data/) folder. To use this sample data, copy one of the folders to `~/undercut-f1/data` and then it will be visible in step 4 below.
+Data for pre-recorded sessions should be stored in the `<data-directory>/<session-name>` directory. Sample data can be found in this repos [Sample Data](/Sample%20Data/) folder. To use this sample data, copy one of the folders to [the configured data directory](#default-directories) and then it will be visible in step 4 below.
 
-1. OPTIONAL: Download sample data to ~/undercut-f1/data. If you already have data, or have checked out the repository, skip to the next step.
+1. OPTIONAL: Download sample data to [the configured data directory](#default-directories). If you already have data, or have checked out the repository, skip to the next step.
 
     ```sh
     # Import data from the 2025 race in Suzuka
@@ -243,15 +242,30 @@ There is a global cursor that is controlled with the <kbd>▼</kbd>/<kbd>▲</kb
 
 ## Configuration
 
-UndercutF1 can be configured using either a simple `config.json` file, through the command line at startup, or using environment variables. JSON configuration will be loaded from `~/undercut-f1/config.json`, if it exists.
+UndercutF1 can be configured using either a simple `config.json` file, through the command line at startup, or using environment variables. JSON configuration will be loaded from [the appropriate config file path](#default-directories), if it exists.
 
-| JSON Path       | Command Line       | Environment Variable       | Description                                                                                                                                                              |
-| --------------- | ------------------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `dataDirectory` | `--data-directory` | `UNDERCUTF1_DATADIRECTORY` | The directory to which JSON timing data is read or written from. This directory is also where Whisper models will be stored (if downloaded) for team radio transcription |
-| `logDirectory`  | `--log-directory`  | `UNDERCUTF1_LOGDIRECTORY`  | The directory to which logs are written to.                                                                                                                              |
-| `verbose`       | `-v\|--verbose`    | `UNDERCUTF1_VERBOSE`       | Whether verbose logging should be enabled. Default: `false`. Values: `true` or `false`.                                                                                  |
-| `apiEnabled`    | `--with-api`       | `UNDERCUTF1_APIENABLED`    | Whether the app should expose an API at <http://localhost:61937>. Default: `false`. Values: `true` or `false`.                                                           |
-| `notify`        | `--notify`         | `UNDERCUTF1_NOTIFY`        | Whether the app should sent audible BELs to your terminal when new race control messages are received. Default: `true`. Values: `true` or `false`.                       |
+To view what configuration is currently being used, open the <kbd>I</kbd> `Info` screen when the app starts up.
+
+| JSON Path       | Command Line       | Environment Variable       | Description                                                                                                                                                               |
+| --------------- | ------------------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataDirectory` | `--data-directory` | `UNDERCUTF1_DATADIRECTORY` | The directory to which JSON timing data is read or written from. This directory is also where Whisper models will be stored (if downloaded) for team radio transcription. |
+| `logDirectory`  | `--log-directory`  | `UNDERCUTF1_LOGDIRECTORY`  | The directory to which logs are written to.                                                                                                                               |
+| `verbose`       | `-v\|--verbose`    | `UNDERCUTF1_VERBOSE`       | Whether verbose logging should be enabled. Default: `false`. Values: `true` or `false`.                                                                                   |
+| `apiEnabled`    | `--with-api`       | `UNDERCUTF1_APIENABLED`    | Whether the app should expose an API at <http://localhost:61937>. Default: `false`. Values: `true` or `false`.                                                            |
+| `notify`        | `--notify`         | `UNDERCUTF1_NOTIFY`        | Whether the app should sent audible BELs to your terminal when new race control messages are received. Default: `true`. Values: `true` or `false`.                        |
+
+### Default Directories
+
+UndercutF1 tries to adhere the Windows and XDG standards as much as possible. By default, timing data and logs are written/read at the following directories:
+
+| Type        | Windows                                | Linux/Mac                                  | Linux/Mac Fallback                  |
+| ----------- | -------------------------------------- | ------------------------------------------ | ----------------------------------- |
+| Config File | `$env:APPDATA/undercut-f1/config.json` | `$XDG_CONFIG_HOME/undercut-f1/config.json` | `~/.config/undercut-f1/config.json` |
+| Data        | `$env:LOCALAPPDATA/undercut-f1/data`   | `$XDG_DATA_HOME/undercut-f1/data`          | `~/.local/share/undercut-f1/data`   |
+| Logs        | `$env:LOCALAPPDATA/undercut-f1/logs`   | `$XDG_STATE_HOME/undercut-f1/logs`         | `~/.local/state/undercut-f1/logs`   |
+
+Data and Logs paths can be configured as [described above](#configuration). 
+The config file location cannot be modified, and will always be read from the above location.
 
 ## Logging
 
@@ -260,7 +274,7 @@ UndercutF1 can be configured using either a simple `config.json` file, through t
 When running `undercutf1` logs are available in two places:
 
 - Logs are stored in memory and viewable the <kbd>L</kbd> `Logs` screen. Logs can be scrolled on this screen, and the minimum level of logs shown can be changed with the <kbd>M</kbd> `Minimum Log Level` action.
-- Log files are written to `~/undercut-f1/logs`.
+- Log files are written to the [configured log directory](#default-directories).
 
 Default log level is set to `Information`. More verbose logging can be enabled with the [`verbose` config option](#configuration).
 
@@ -289,7 +303,7 @@ F1 live timing is streamed using `SignalR`. The `UndercutF1.Data` simply connect
 
 ## Data Recording and Replay
 
-All events received by the live timing client will be written to the configured `Data Directory`, see [see Configuration for details](#configuration). Files will be written to a subdirectory named using the current sessions name, e.g. `~/undercut-f1/data/Jeddah_Race/`. In this directory, two files will be written:
+All events received by the live timing client will be written to the configured `Data Directory`, see [see Configuration for details](#configuration). Files will be written to a subdirectory named using the current sessions name, e.g. `<data-directory>/Jeddah_Race/`. In this directory, two files will be written:
 
 - `subscribe.txt` contains the data received at subscription time (i.e. when the live timing client connected to the stream)
 - `live.txt` contains an append-log of every message received in the stream

--- a/README.md
+++ b/README.md
@@ -208,21 +208,15 @@ Data for pre-recorded sessions should be stored in the `~/undercut-f1/data/<sess
 1. OPTIONAL: Download sample data to ~/undercut-f1/data. If you already have data, or have checked out the repository, skip to the next step.
 
     ```sh
-    # Create the directory for the data if it doesn't exist
-    mkdir -p ~/undercut-f1/2024_Silverstone_Race
-
-    # Download the live and subscribe data files
-    curl https://raw.githubusercontent.com/JustAman62/undercut-f1/refs/heads/master/Sample%20Data/2024_Silverstone_Race/live.txt -o ~/undercut-f1/2024_Silverstone_Race/live.txt
-
-    curl https://raw.githubusercontent.com/JustAman62/undercut-f1/refs/heads/master/Sample%20Data/2024_Silverstone_Race/subscribe.txt -o ~/undercut-f1/2024_Silverstone_Race/subscribe.txt
+    # Import data from the 2025 race in Suzuka
+    undercutf1 import 2025 --meeting-key 1256 --session-key 10006
     ```
 
 2. Start `undercutf1` as described [above](#installation)
 3. Navigate to the <kbd>S</kbd> `Session` Screen
 4. Start a Simulated Session with the <kbd>F</kbd> `Start Simulation` action.
 5. Select the session to start using the Up/Down arrows, then pressing <kbd>Enter</kbd>
-6. Switch to the Timing Tower screen with the <kbd>T</kbd> `Timing Tower` action
-7. Optionally skip forward in time a bit by decreasing the delay with <kbd>N</kbd> (or <kbd>⇧ Shift</kbd> + <kbd>N</kbd> to decrease by 30 seconds).
+6. Skip forward in time a bit by decreasing the delay with <kbd>N</kbd> (or <kbd>⇧ Shift</kbd> + <kbd>N</kbd> to decrease by 30 seconds).
 
 ### Download a previous session data for replay
 
@@ -231,19 +225,21 @@ F1 provides static timing data files for already completed sessions. This data c
 1. List the meetings that have data available to import with `undercutf1 import <year>`
 2. Review the list of meetings returned from the command, and list the available sessions inside the chosen meeting with `undercutf1 import <year> --meeting-key <meeting-key>`
 3. Review the list of sessions, and select one to import: `undercutf1 import <year> --meeting-key <meeting-key> --session-key <session-key>`
-4. Data that is imported will be saved to the configured `DATA_DIRECTORY`. See [Configuration](#configuration) for information on how to change this.
+4. Data that is imported will be saved to the configured data directory. See [Configuration](#configuration) for information on how to change this.
 
 ### During the Session
 
 #### Managing Delay
 
-All session data, whether live or pre-recorded, is sent to a `Channel` that acts as a delayed-queue. After a short delay, data points are pulled from the queue and processed, leading to updates on the timing screens. The amount of this delay can be changed with the <kbd>M</kbd>/<kbd>N</kbd> `Delay` actions whilst on the timing screens. Hold <kbd>⇧ Shift</kbd> to change the delay by 30 seconds instead of 5. Use the <kbd>,</kbd>/<kbd>.</kbd> keys to change by 1 second. When using `undercutf1` during a live session, you may wish to increase this delay to around ~50 seconds (actual number may vary) to match with the broadcast delay and avoid being spoiled about upcoming action.
+All session data, whether live or pre-recorded, is sent to a `Channel` that acts as a delayed-queue. After your currently configured delay delay, data points are pulled from the queue and processed, leading to updates on the timing screens. The amount of this delay can be changed with the <kbd>M</kbd>/<kbd>N</kbd> `Delay` actions whilst on the timing screens. Hold <kbd>⇧ Shift</kbd> to change the delay by 30 seconds instead of 5. Use the <kbd>,</kbd>/<kbd>.</kbd> keys to change by 1 second. When using `undercutf1` during a live session, you may wish to increase this delay to around ~50 seconds (actual number may vary) to match with the broadcast delay and avoid being spoiled about upcoming action.
 
 Simulated sessions start with a calculated delay equal to the amount of time between the start of the actual session and now. This means you can decrease the delay with the <kbd>N</kbd> `Delay` action to fast-forward through the session.
 
+Data processing, and therefore the "session clock" can be paused using the <kbd>P</kbd> `Pause Clock` action. This allows you to easily synchronize prerecorded sessions by pausing the session in UndercutF1, then resuming at the perfect time when, for example, the formation lap starts.
+
 #### Using the Cursor
 
-There is a global cursor that is controlled with the <kbd>▼</kbd>/<kbd>▲</kbd> `Cursor` actions. What this cursor does depends on the screen, for example is can be used in the Timing Tower screen to scroll through Race Control Messages, or to select a driver on the Tower to see comparative intervals.
+There is a global cursor that is controlled with the <kbd>▼</kbd>/<kbd>▲</kbd> `Cursor` actions. What this cursor does depends on the screen, for example is can be used in the Timing Tower screen to scroll through Race Control Messages, or to select a driver on the Tower to see comparative intervals. Hold the <kbd>⇧ Shift</kbd> key to move the cursor by five positions instead of one.
 
 ## Configuration
 
@@ -288,6 +284,7 @@ F1 live timing is streamed using `SignalR`. The `UndercutF1.Data` simply connect
 - `Position.z`
 - `ChampionshipPrediction`
 - `TeamRadio`
+- `TyreStintSeries`
 
 ## Data Recording and Replay
 

--- a/README.md
+++ b/README.md
@@ -245,12 +245,13 @@ There is a global cursor that is controlled with the <kbd>▼</kbd>/<kbd>▲</kb
 
 UndercutF1 can be configured using either a simple `config.json` file, through the command line at startup, or using environment variables. JSON configuration will be loaded from `~/undercut-f1/config.json`, if it exists.
 
-| JSON Path       | Command Line       | Environment Variable       | Description                                                                                                                                        |
-| --------------- | ------------------ | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataDirectory` | `--data-directory` | `UNDERCUTF1_DATADIRECTORY` | The directory in which JSON timing data is read or written from.                                                                                   |
-| `verbose`       | `-v\|--verbose`    | `UNDERCUTF1_VERBOSE`       | Whether verbose logging should be enabled. Default: `false`. Values: `true` or `false`.                                                            |
-| `apiEnabled`    | `--with-api`       | `UNDERCUTF1_APIENABLED`    | Whether the app should expose an API at <http://localhost:61937>. Default: `false`. Values: `true` or `false`.                                     |
-| `notify`        | `--notify`         | `UNDERCUTF1_NOTIFY`        | Whether the app should sent audible BELs to your terminal when new race control messages are received. Default: `true`. Values: `true` or `false`. |
+| JSON Path       | Command Line       | Environment Variable       | Description                                                                                                                                                              |
+| --------------- | ------------------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `dataDirectory` | `--data-directory` | `UNDERCUTF1_DATADIRECTORY` | The directory to which JSON timing data is read or written from. This directory is also where Whisper models will be stored (if downloaded) for team radio transcription |
+| `logDirectory`  | `--log-directory`  | `UNDERCUTF1_LOGDIRECTORY`  | The directory to which logs are written to.                                                                                                                              |
+| `verbose`       | `-v\|--verbose`    | `UNDERCUTF1_VERBOSE`       | Whether verbose logging should be enabled. Default: `false`. Values: `true` or `false`.                                                                                  |
+| `apiEnabled`    | `--with-api`       | `UNDERCUTF1_APIENABLED`    | Whether the app should expose an API at <http://localhost:61937>. Default: `false`. Values: `true` or `false`.                                                           |
+| `notify`        | `--notify`         | `UNDERCUTF1_NOTIFY`        | Whether the app should sent audible BELs to your terminal when new race control messages are received. Default: `true`. Values: `true` or `false`.                       |
 
 ## Logging
 

--- a/UndercutF1.Console/CommandHandler.ImportSession.cs
+++ b/UndercutF1.Console/CommandHandler.ImportSession.cs
@@ -10,11 +10,13 @@ public static partial class CommandHandler
         int? meetingKey,
         int? sessionKey,
         DirectoryInfo? dataDirectory,
+        DirectoryInfo? logDirectory,
         bool isVerbose
     )
     {
         var builder = GetBuilder(
             dataDirectory: dataDirectory,
+            logDirectory: logDirectory,
             isVerbose: isVerbose,
             useConsoleLogging: true
         );

--- a/UndercutF1.Console/CommandHandler.ListMeetings.cs
+++ b/UndercutF1.Console/CommandHandler.ListMeetings.cs
@@ -5,9 +5,18 @@ namespace UndercutF1.Console;
 
 public static partial class CommandHandler
 {
-    public static async Task ListMeetings(int year, int? meetingKey, bool isVerbose)
+    public static async Task ListMeetings(
+        int year,
+        int? meetingKey,
+        DirectoryInfo? logDirectory,
+        bool isVerbose
+    )
     {
-        var builder = GetBuilder(isVerbose: isVerbose, useConsoleLogging: true);
+        var builder = GetBuilder(
+            isVerbose: isVerbose,
+            logDirectory: logDirectory,
+            useConsoleLogging: true
+        );
         var app = builder.Build();
 
         var importer = app.Services.GetRequiredService<IDataImporter>();

--- a/UndercutF1.Console/CommandHandler.Root.cs
+++ b/UndercutF1.Console/CommandHandler.Root.cs
@@ -10,7 +10,8 @@ public static partial class CommandHandler
 {
     public static async Task Root(
         bool isApiEnabled,
-        DirectoryInfo dataDirectory,
+        DirectoryInfo? dataDirectory,
+        DirectoryInfo? logDirectory,
         bool isVerbose,
         bool? notifyEnabled
     )
@@ -18,6 +19,7 @@ public static partial class CommandHandler
         var builder = GetBuilder(
             isApiEnabled: isApiEnabled,
             dataDirectory: dataDirectory,
+            logDirectory: logDirectory,
             isVerbose: isVerbose,
             notifyEnabled: notifyEnabled
         );

--- a/UndercutF1.Console/CommandHandler.cs
+++ b/UndercutF1.Console/CommandHandler.cs
@@ -37,10 +37,7 @@ public static partial class CommandHandler
         }
 
         builder
-            .Configuration.AddJsonFile(
-                Path.Join(LiveTimingOptions.BaseDirectory, "config.json"),
-                optional: true
-            )
+            .Configuration.AddJsonFile(LiveTimingOptions.ConfigFilePath, optional: true)
             .AddEnvironmentVariables("UNDERCUTF1_")
             .AddInMemoryCollection(commandLineOpts);
 

--- a/UndercutF1.Console/CommandHandler.cs
+++ b/UndercutF1.Console/CommandHandler.cs
@@ -11,6 +11,7 @@ public static partial class CommandHandler
     private static WebApplicationBuilder GetBuilder(
         bool isApiEnabled = false,
         DirectoryInfo? dataDirectory = null,
+        DirectoryInfo? logDirectory = null,
         bool isVerbose = false,
         bool? notifyEnabled = null,
         bool useConsoleLogging = false
@@ -31,6 +32,10 @@ public static partial class CommandHandler
         {
             commandLineOpts.Add(nameof(LiveTimingOptions.DataDirectory), dataDirectory?.FullName);
         }
+        if (logDirectory is not null)
+        {
+            commandLineOpts.Add(nameof(LiveTimingOptions.LogDirectory), logDirectory?.FullName);
+        }
         if (notifyEnabled is not null)
         {
             commandLineOpts.Add(nameof(LiveTimingOptions.Notify), notifyEnabled.ToString());
@@ -50,7 +55,7 @@ public static partial class CommandHandler
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Is(fileLogLevel)
             .WriteTo.File(
-                path: Path.Join(LiveTimingOptions.BaseDirectory, "logs/undercutf1.log"),
+                path: Path.Join(options.LogDirectory, "/undercutf1.log"),
                 rollOnFileSizeLimit: true,
                 rollingInterval: RollingInterval.Hour,
                 retainedFileCountLimit: 5

--- a/UndercutF1.Console/ConsoleLoop.cs
+++ b/UndercutF1.Console/ConsoleLoop.cs
@@ -203,23 +203,42 @@ public class ConsoleLoop(
                         )
                     )
                     .Select(x =>
-                        x.ExecuteAsync(
-                            new ConsoleKeyInfo(
-                                keyChar,
+                    {
+                        try
+                        {
+                            return x.ExecuteAsync(
+                                new ConsoleKeyInfo(
+                                    keyChar,
+                                    consoleKey,
+                                    shift: modifiers.HasFlag(ConsoleModifiers.Shift),
+                                    alt: false,
+                                    control: modifiers.HasFlag(ConsoleModifiers.Control)
+                                ),
+                                cancellationToken
+                            );
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogError(
+                                ex,
+                                "Failed to handle input {Key} for {Name}",
                                 consoleKey,
-                                shift: modifiers.HasFlag(ConsoleModifiers.Shift),
-                                alt: false,
-                                control: modifiers.HasFlag(ConsoleModifiers.Control)
-                            ),
-                            cancellationToken
-                        )
-                    );
+                                x.Description
+                            );
+                            return Task.CompletedTask;
+                        }
+                    });
                 await Task.WhenAll(tasks);
             }
         }
         catch (OperationCanceledException)
         {
             // No input to read, so skip
+            return;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to handle input");
             return;
         }
         finally

--- a/UndercutF1.Console/Display/InfoDisplay.cs
+++ b/UndercutF1.Console/Display/InfoDisplay.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using UndercutF1.Data;
+
+namespace UndercutF1.Console;
+
+public sealed class InfoDisplay(
+    TerminalInfoProvider terminalInfo,
+    IOptions<LiveTimingOptions> options
+) : IDisplay
+{
+    public Screen Screen => Screen.Info;
+
+    public Task<IRenderable> GetContentAsync()
+    {
+        var content = $"""
+            [bold]Configuration[/]
+            [bold]Data Directory:[/]        {options.Value.DataDirectory}
+            [bold]Log Directory:[/]         {LiveTimingOptions.BaseDirectory}/logs
+            [bold]Audible Notifications:[/] {options.Value.Notify}
+            [bold]Verbose Mode:[/]          {options.Value.Verbose}
+            [bold]Config Override File:[/]  {File.Exists(
+                LiveTimingOptions.ConfigFilePath
+            )} ({LiveTimingOptions.ConfigFilePath})
+            See https://github.com/JustAman62/undercut-f1#configuration for information on how to configure these options.
+
+            [bold]Terminal Diagnostics[/]
+            [bold]TERM_PROGRAM:[/]        {Environment.GetEnvironmentVariable("TERM_PROGRAM")}
+            [bold]Kitty Supported:[/]     {terminalInfo.IsKittyProtocolSupported.Value}
+            [bold]iTerm2 Supported:[/]    {terminalInfo.IsITerm2ProtocolSupported.Value}
+            [bold]Synchronized Output:[/] {terminalInfo.IsSynchronizedOutputSupported.Value}
+            [bold]Version:[/]             {ThisAssembly.AssemblyInformationalVersion}
+            """;
+
+        return Task.FromResult<IRenderable>(new Panel(new Markup(content)).Expand());
+    }
+}

--- a/UndercutF1.Console/Display/InfoDisplay.cs
+++ b/UndercutF1.Console/Display/InfoDisplay.cs
@@ -19,7 +19,7 @@ public sealed class InfoDisplay(
         var content = $"""
             [bold]Configuration[/]
             [bold]Data Directory:[/]        {options.Value.DataDirectory}
-            [bold]Log Directory:[/]         {LiveTimingOptions.BaseDirectory}/logs
+            [bold]Log Directory:[/]         {options.Value.LogDirectory}
             [bold]Audible Notifications:[/] {options.Value.Notify}
             [bold]Verbose Mode:[/]          {options.Value.Verbose}
             [bold]Config Override File:[/]  {File.Exists(

--- a/UndercutF1.Console/Input/SwitchToInfoInputHandler.cs
+++ b/UndercutF1.Console/Input/SwitchToInfoInputHandler.cs
@@ -1,0 +1,23 @@
+namespace UndercutF1.Console;
+
+public class SwitchToInfoInputHandler(State state) : IInputHandler
+{
+    public bool IsEnabled => true;
+
+    public Screen[] ApplicableScreens => [Screen.Main];
+
+    public ConsoleKey[] Keys => [ConsoleKey.I];
+
+    public string Description => "Info";
+
+    public int Sort => 69;
+
+    public async Task ExecuteAsync(
+        ConsoleKeyInfo consoleKeyInfo,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await Terminal.OutAsync(ControlSequences.ClearScreen(ClearMode.Full), cancellationToken);
+        state.CurrentScreen = Screen.Info;
+    }
+}

--- a/UndercutF1.Console/Program.cs
+++ b/UndercutF1.Console/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.CommandLine;
 using UndercutF1.Console;
+using UndercutF1.Data;
 
 var rootCommand = new RootCommand("undercutf1");
 
@@ -13,9 +14,13 @@ var isApiEnabledOption = new Option<bool>(
     () => false,
     "Whether the API endpoint should be exposed at http://localhost:61937"
 );
-var dataDirectoryOption = new Option<DirectoryInfo>(
+var dataDirectoryOption = new Option<DirectoryInfo?>(
     "--data-directory",
     "The directory to which timing data will be read from and written to"
+);
+var logDirectoryOption = new Option<DirectoryInfo?>(
+    "--log-directory",
+    "The directory to which logs will be written to"
 );
 var notifyOption = new Option<bool?>(
     "--notify",
@@ -25,12 +30,14 @@ var notifyOption = new Option<bool?>(
 rootCommand.AddGlobalOption(isVerboseOption);
 rootCommand.AddGlobalOption(isApiEnabledOption);
 rootCommand.AddGlobalOption(dataDirectoryOption);
+rootCommand.AddGlobalOption(logDirectoryOption);
 rootCommand.AddGlobalOption(notifyOption);
 
 rootCommand.SetHandler(
     CommandHandler.Root,
     isApiEnabledOption,
     dataDirectoryOption,
+    logDirectoryOption,
     isVerboseOption,
     notifyOption
 );
@@ -63,6 +70,7 @@ importCommand.SetHandler(
     meetingKeyOption,
     sessionKeyOption,
     dataDirectoryOption,
+    logDirectoryOption,
     isVerboseOption
 );
 
@@ -82,6 +90,7 @@ importListCommand.SetHandler(
     CommandHandler.ListMeetings,
     yearArgument,
     meetingKeyOption,
+    logDirectoryOption,
     isVerboseOption
 );
 

--- a/UndercutF1.Console/Screen.cs
+++ b/UndercutF1.Console/Screen.cs
@@ -16,4 +16,5 @@ public enum Screen
     TyreStints,
     DebugData,
     DownloadTranscriptionModel,
+    Info,
 }

--- a/UndercutF1.Console/UndercutF1.Console.csproj
+++ b/UndercutF1.Console/UndercutF1.Console.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="NetCoreAudio" />
     <PackageReference Include="Serilog" />

--- a/UndercutF1.Data/DataImporter.cs
+++ b/UndercutF1.Data/DataImporter.cs
@@ -7,8 +7,11 @@ using Microsoft.Extensions.Options;
 
 namespace UndercutF1.Data;
 
-public sealed class DataImporter(IOptions<LiveTimingOptions> options, ILogger<DataImporter> logger)
-    : IDataImporter
+public sealed class DataImporter(
+    IHttpClientFactory httpClientFactory,
+    IOptions<LiveTimingOptions> options,
+    ILogger<DataImporter> logger
+) : IDataImporter
 {
     private static readonly string[] _raceTopics =
     [
@@ -53,8 +56,7 @@ public sealed class DataImporter(IOptions<LiveTimingOptions> options, ILogger<Da
     /// <inheritdoc />
     public async Task<ListMeetingsApiResponse> GetMeetingsAsync(int year)
     {
-        // TODO: Get this HttpClient from DI IHttpClientFactory
-        var httpClient = new HttpClient();
+        var httpClient = httpClientFactory.CreateClient("Default");
         var url = $"https://livetiming.formula1.com/static/{year}/Index.json";
         return await httpClient.GetFromJsonAsync<ListMeetingsApiResponse>(url).ConfigureAwait(false)
             ?? throw new InvalidOperationException("An error occurred parsing the API response");
@@ -192,8 +194,7 @@ public sealed class DataImporter(IOptions<LiveTimingOptions> options, ILogger<Da
 
         try
         {
-            // TODO: Get this HttpClient from DI IHttpClientFactory
-            var httpClient = new HttpClient();
+            var httpClient = httpClientFactory.CreateClient("Default");
             var rawData = await httpClient.GetStringAsync(url).ConfigureAwait(false);
             var lines = rawData.Split('\n');
             return lines

--- a/UndercutF1.Data/Options/LiveTimingOptions.cs
+++ b/UndercutF1.Data/Options/LiveTimingOptions.cs
@@ -5,24 +5,33 @@ namespace UndercutF1.Data;
 /// </summary>
 public record LiveTimingOptions
 {
-    public static string BaseDirectory =>
-        Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "undercut-f1");
-
-    public static string ConfigFilePath => Path.Join(BaseDirectory, "config.json");
+    /// <summary>
+    /// Try to conform to Windows/XDG directory standards by default.
+    /// <see cref="Environment.SpecialFolder.ApplicationData"/> will return <c>%APPDATA%</c> on Windows,
+    /// <c>$XDG_CONFIG_HOME</c> or <c>~/.config</c> on Linux/Mac.
+    /// </summary>
+    ///
+    /// <returns>
+    /// <c>%APPDATA%/undercut-f1/config.json</c> on Windows,
+    /// <c>$XDG_CONFIG_HOME/undercut-f1/config.json</c> or <c>~/.config/undercut-f1/config.json</c> on Mac/Linux.
+    /// </returns>
+    public static string ConfigFilePath => GetConfigFilePath();
 
     /// <summary>
     /// The directory to read and store live timing data for simulations.
     /// When live sessions are being listened to, all data received will be recorded in this directory.
     /// This is also the directory that imported data is saved to.
-    /// Defaults to <c>~/undercut-f1/data</c>.
+    ///
+    /// Defaults to <c>%LOCALAPPDATA%/undercut-f1/data</c> on Windows,
+    /// <c>$XDG_DATA_HOME/undercut-f1/data</c> or <c>~/.local/share</c> on Mac/Linux.
     /// </summary>
-    public string DataDirectory { get; set; } = Path.Join(BaseDirectory, "data");
+    public string DataDirectory { get; set; } = GetDefaultDataDirectory();
 
     /// <summary>
     /// The directory where logs will be output to.
     /// Defaults to <c>~/undercut-f1/logs</c>
     /// </summary>
-    public string LogDirectory { get; set; } = Path.Join(BaseDirectory, "logs");
+    public string LogDirectory { get; set; } = GetDefaultLogDirectory();
 
     /// <summary>
     /// Whether the app should expose an API at http://localhost:61937.
@@ -42,4 +51,102 @@ public record LiveTimingOptions
     /// UndercutF1.Console implements these notifications as <c>BEL</c>s sent to your terminal, resulting in an audible beep.
     /// </summary>
     public bool Notify { get; set; } = true;
+
+    private static string GetConfigFilePath()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return Path.Join(
+                Environment.GetFolderPath(
+                    Environment.SpecialFolder.ApplicationData,
+                    Environment.SpecialFolderOption.Create
+                ),
+                "undercut-f1",
+                "config.json"
+            );
+        }
+        else
+        {
+            var xdgConfigDirectory = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+            if (string.IsNullOrWhiteSpace(xdgConfigDirectory))
+            {
+                xdgConfigDirectory = Path.Join(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".config"
+                );
+            }
+
+            return Path.Join(xdgConfigDirectory, "undercut-f1", "config.json");
+        }
+    }
+
+    /// <summary>
+    /// Try to conform to Windows/XDG directory standards by default.
+    /// <see cref="Environment.SpecialFolder.LocalApplicationData"/> will return <c>%LOCALAPPDATA%</c> on Windows.
+    /// On Linux/Mac, we will try to use <c>$XDG_DATA_HOME</c> or <c>~/.local/share</c>.
+    /// </summary>
+    private static string GetDefaultDataDirectory()
+    {
+        // NOTE: Environment.SpecialFolder.LocalApplicationData returns ~/Library/Application Support on Mac,
+        // so using the environment variables directly on Mac/Linux to keep them both using XDG standards.
+        if (OperatingSystem.IsWindows())
+        {
+            return Path.Join(
+                Environment.GetFolderPath(
+                    Environment.SpecialFolder.LocalApplicationData,
+                    Environment.SpecialFolderOption.Create
+                ),
+                "undercut-f1",
+                "data"
+            );
+        }
+        else
+        {
+            var xdgDataDirectory = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+            if (string.IsNullOrWhiteSpace(xdgDataDirectory))
+            {
+                xdgDataDirectory = Path.Join(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".local",
+                    "share"
+                );
+            }
+
+            return Path.Join(xdgDataDirectory, "undercut-f1", "data");
+        }
+    }
+
+    /// <summary>
+    /// Try to conform to Windows/XDG directory standards by default.
+    /// <see cref="Environment.SpecialFolder.LocalApplicationData"/> will return <c>%LOCALAPPDATA%</c> on Windows.
+    /// On Linux/Mac, we will try to use <c>$XDG_STATE_HOME</c> or <c>~/.local/state</c>
+    /// </summary>
+    private static string GetDefaultLogDirectory()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return Path.Join(
+                Environment.GetFolderPath(
+                    Environment.SpecialFolder.LocalApplicationData,
+                    Environment.SpecialFolderOption.Create
+                ),
+                "undercut-f1",
+                "logs"
+            );
+        }
+        else
+        {
+            var xdgStateDirectory = Environment.GetEnvironmentVariable("XDG_STATE_HOME");
+            if (string.IsNullOrWhiteSpace(xdgStateDirectory))
+            {
+                xdgStateDirectory = Path.Join(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".local",
+                    "state"
+                );
+            }
+
+            return Path.Join(xdgStateDirectory, "undercut-f1", "logs");
+        }
+    }
 }

--- a/UndercutF1.Data/Options/LiveTimingOptions.cs
+++ b/UndercutF1.Data/Options/LiveTimingOptions.cs
@@ -19,6 +19,12 @@ public record LiveTimingOptions
     public string DataDirectory { get; set; } = Path.Join(BaseDirectory, "data");
 
     /// <summary>
+    /// The directory where logs will be output to.
+    /// Defaults to <c>~/undercut-f1/logs</c>
+    /// </summary>
+    public string LogDirectory { get; set; } = Path.Join(BaseDirectory, "logs");
+
+    /// <summary>
     /// Whether the app should expose an API at http://localhost:61937.
     /// Defaults to <c>false</c>.
     /// </summary>

--- a/UndercutF1.Data/Options/LiveTimingOptions.cs
+++ b/UndercutF1.Data/Options/LiveTimingOptions.cs
@@ -8,6 +8,8 @@ public record LiveTimingOptions
     public static string BaseDirectory =>
         Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "undercut-f1");
 
+    public static string ConfigFilePath => Path.Join(BaseDirectory, "config.json");
+
     /// <summary>
     /// The directory to read and store live timing data for simulations.
     /// When live sessions are being listened to, all data received will be recorded in this directory.

--- a/UndercutF1.Data/Processors/SessionInfoProcessor.cs
+++ b/UndercutF1.Data/Processors/SessionInfoProcessor.cs
@@ -6,8 +6,11 @@ using Microsoft.Extensions.Logging;
 
 namespace UndercutF1.Data;
 
-public class SessionInfoProcessor(IMapper mapper, ILogger<SessionInfoProcessor> logger)
-    : ProcessorBase<SessionInfoDataPoint>(mapper)
+public class SessionInfoProcessor(
+    IHttpClientFactory httpClientFactory,
+    IMapper mapper,
+    ILogger<SessionInfoProcessor> logger
+) : ProcessorBase<SessionInfoDataPoint>(mapper)
 {
     private Task? _loadCircuitTask = null;
     private JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web)
@@ -39,11 +42,7 @@ public class SessionInfoProcessor(IMapper mapper, ILogger<SessionInfoProcessor> 
         try
         {
             logger.LogInformation("Loading circuit data for key {CircuitKey}", circuitKey);
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Add(
-                "User-Agent",
-                $"undercut-f1/{ThisAssembly.AssemblyInformationalVersion}"
-            );
+            var httpClient = httpClientFactory.CreateClient("Default");
             var url =
                 $"https://api.multiviewer.app/api/v1/circuits/{circuitKey}/{DateTimeOffset.UtcNow.Year}";
             var circuitInfo = await httpClient

--- a/UndercutF1.Data/Processors/TeamRadioProcessor.cs
+++ b/UndercutF1.Data/Processors/TeamRadioProcessor.cs
@@ -32,7 +32,9 @@ public class TeamRadioProcessor(
 
         var downloadUri =
             $"https://livetiming.formula1.com/static/{sessionInfoProcessor.Latest.Path}{radio.Path}";
-        var destFilePath = $"{Path.GetTempFileName()}.mp3";
+
+        var radioPath = radio.Path!.Replace("TeamRadio/", string.Empty);
+        var destFilePath = Path.Join(Path.GetTempPath(), radioPath);
 
         var httpClient = httpClientFactory.CreateClient("Default");
         var downloadStream = await httpClient

--- a/UndercutF1.Data/Processors/TeamRadioProcessor.cs
+++ b/UndercutF1.Data/Processors/TeamRadioProcessor.cs
@@ -5,6 +5,7 @@ namespace UndercutF1.Data;
 public class TeamRadioProcessor(
     SessionInfoProcessor sessionInfoProcessor,
     ITranscriptionProvider transcriptionProvider,
+    IHttpClientFactory httpClientFactory,
     IMapper mapper
 ) : ProcessorBase<TeamRadioDataPoint>(mapper)
 {
@@ -33,8 +34,7 @@ public class TeamRadioProcessor(
             $"https://livetiming.formula1.com/static/{sessionInfoProcessor.Latest.Path}{radio.Path}";
         var destFilePath = $"{Path.GetTempFileName()}.mp3";
 
-        // TODO: Use DI based HttpClients
-        using var httpClient = new HttpClient();
+        var httpClient = httpClientFactory.CreateClient("Default");
         var downloadStream = await httpClient
             .GetStreamAsync(downloadUri, cancellationToken)
             .ConfigureAwait(false);

--- a/UndercutF1.Data/ServiceCollectionExtensions.cs
+++ b/UndercutF1.Data/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper.EquivalencyExpression;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
 using UndercutF1.Data.AutoMapper;
 
 namespace UndercutF1.Data;
@@ -31,7 +32,17 @@ public static partial class ServiceCollectionExtensions
             .AddLiveTimingProcessors()
             .AddSingleton<INotifyService, NotifyService>()
             .AddSingleton<ITranscriptionProvider, TranscriptionProvider>()
-            .AddSingleton<IDataImporter, DataImporter>();
+            .AddSingleton<IDataImporter, DataImporter>()
+            .AddHttpClient(
+                "Default",
+                options =>
+                {
+                    options.DefaultRequestHeaders.Add(
+                        "User-Agent",
+                        $"undercut-f1/{ThisAssembly.AssemblyInformationalVersion}"
+                    );
+                }
+            );
 
         return collection;
     }

--- a/UndercutF1.Data/UndercutF1.Data.csproj
+++ b/UndercutF1.Data/UndercutF1.Data.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Whisper.net" />
     <PackageReference Include="Whisper.net.Runtime" />


### PR DESCRIPTION
* Implement a Info screen which shows the current configuration being used, and where you can go to change it
* Implement a simple version check that checks if the latest GitHub tag is the same as the current version
* Adjust data, log, and config directories to match up to established XDG and Windows standards. See updated README for what directories these are.

Fixes #29 
Fixes #30