### PR TITLE
Chunk kitty graphics sequences to 4000 bytes

### DIFF
--- a/UndercutF1.Console/Display/DriverTrackerDisplay.cs
+++ b/UndercutF1.Console/Display/DriverTrackerDisplay.cs
@@ -57,7 +57,7 @@ public class DriverTrackerDisplay(
 
     private TransformFactors? _transform = null;
 
-    private string _trackMapControlSequence = string.Empty;
+    private string[] _trackMapControlSequence = [];
 
     public Screen Screen => Screen.DriverTracker;
 
@@ -211,7 +211,7 @@ public class DriverTrackerDisplay(
         };
     }
 
-    private string GetTrackMap()
+    private string[] GetTrackMap()
     {
         if (
             !(
@@ -221,7 +221,7 @@ public class DriverTrackerDisplay(
             || sessionInfo.Latest.CircuitPoints.Count == 0
         )
         {
-            return string.Empty;
+            return [];
         }
 
         _transform ??= GetTransformFactors();
@@ -334,15 +334,18 @@ public class DriverTrackerDisplay(
 
         if (terminalInfo.IsKittyProtocolSupported.Value)
         {
-            return TerminalGraphics.KittyGraphicsSequenceDelete()
-                + TerminalGraphics.KittyGraphicsSequence(windowHeight, windowWidth, base64);
+            return
+            [
+                TerminalGraphics.KittyGraphicsSequenceDelete(),
+                .. TerminalGraphics.KittyGraphicsSequence(windowHeight, windowWidth, base64),
+            ];
         }
         else if (terminalInfo.IsITerm2ProtocolSupported.Value)
         {
-            return TerminalGraphics.ITerm2GraphicsSequence(windowHeight, windowWidth, base64);
+            return [TerminalGraphics.ITerm2GraphicsSequence(windowHeight, windowWidth, base64)];
         }
 
-        return "Unexpected error, shouldn't have got here. Please report!";
+        return ["Unexpected error, shouldn't have got here. Please report!"];
     }
 
     private TransformFactors GetTransformFactors()
@@ -381,7 +384,10 @@ public class DriverTrackerDisplay(
     public async Task PostContentDrawAsync()
     {
         await Terminal.OutAsync(ControlSequences.MoveCursorTo(TOP_OFFSET, LEFT_OFFSET));
-        await Terminal.OutAsync(_trackMapControlSequence);
+        foreach (var sequence in _trackMapControlSequence)
+        {
+            await Terminal.OutAsync(sequence);
+        }
     }
 
     private record TransformFactors(int ScaleFactor, int ShiftX, int ShiftY, int MaxX, int MaxY);

--- a/UndercutF1.Console/Display/TimingHistoryDisplay.cs
+++ b/UndercutF1.Console/Display/TimingHistoryDisplay.cs
@@ -49,7 +49,7 @@ public class TimingHistoryDisplay(
         slant: SKFontStyleSlant.Upright
     );
 
-    private string _chartPanelControlSequence = string.Empty;
+    private string[] _chartPanelControlSequence = [];
 
     public Task<IRenderable> GetContentAsync()
     {
@@ -66,7 +66,10 @@ public class TimingHistoryDisplay(
     public async Task PostContentDrawAsync()
     {
         await Terminal.OutAsync(ControlSequences.MoveCursorTo(0, LEFT_OFFSET));
-        await Terminal.OutAsync(_chartPanelControlSequence);
+        foreach (var sequence in _chartPanelControlSequence)
+        {
+            await Terminal.OutAsync(sequence);
+        }
     }
 
     private IRenderable GetTimingTower()
@@ -171,19 +174,19 @@ public class TimingHistoryDisplay(
         return _normal;
     }
 
-    private string GetChartPanel()
+    private string[] GetChartPanel()
     {
         if (
             !terminalInfo.IsITerm2ProtocolSupported.Value
             && !terminalInfo.IsKittyProtocolSupported.Value
         )
         {
-            return string.Empty;
+            return [];
         }
 
         if (!sessionInfo.Latest.IsRace())
         {
-            return string.Empty;
+            return [];
         }
 
         var widthCells = Terminal.Size.Width - LEFT_OFFSET;
@@ -331,15 +334,18 @@ public class TimingHistoryDisplay(
 
         if (terminalInfo.IsKittyProtocolSupported.Value)
         {
-            return TerminalGraphics.KittyGraphicsSequenceDelete()
-                + TerminalGraphics.KittyGraphicsSequence(heightCells, widthCells, base64);
+            return
+            [
+                TerminalGraphics.KittyGraphicsSequenceDelete(),
+                .. TerminalGraphics.KittyGraphicsSequence(heightCells, widthCells, base64),
+            ];
         }
         else if (terminalInfo.IsITerm2ProtocolSupported.Value)
         {
-            return TerminalGraphics.ITerm2GraphicsSequence(heightCells, widthCells, base64);
+            return [TerminalGraphics.ITerm2GraphicsSequence(heightCells, widthCells, base64)];
         }
 
-        return "Unexpected error, shouldn't have got here. Please report!";
+        return ["Unexpected error, shouldn't have got here. Please report!"];
     }
 
     private SKCartesianChart CreateChart(


### PR DESCRIPTION
Chunk escape sequences sent to Kitty for the Kitty graphics protocol to 4000 byte chunks, as described in the spec. Chosen 4000 over the recommended 4096 to have a bit of a margin.

The images output are usually around 10KB (i.e. 10000 base64 chars), so we normally send 3 message for each image.

Fixes #8