### PR TITLE
More tuning for driver tracker image

### DIFF
--- a/UndercutF1.Console/Display/DriverTrackerDisplay.cs
+++ b/UndercutF1.Console/Display/DriverTrackerDisplay.cs
@@ -20,8 +20,8 @@ public class DriverTrackerDisplay(
     IOptions<LiveTimingOptions> options
 ) : IDisplay
 {
-    private const int IMAGE_PADDING = 25;
-    private const int TARGET_IMAGE_SIZE = 650;
+    private const int IMAGE_PADDING = 50;
+    private const int TARGET_IMAGE_SIZE = 1200;
     private const int LEFT_OFFSET = 17;
     private const int TOP_OFFSET = 0;
     private const int BOTTOM_OFFSET = 1;
@@ -29,12 +29,12 @@ public class DriverTrackerDisplay(
     private static readonly SKPaint _trackLinePaint = new()
     {
         Color = SKColor.Parse("666666"),
-        StrokeWidth = 4,
+        StrokeWidth = 6,
     };
     private static readonly SKPaint _cornerTextPaint = new()
     {
         Color = SKColor.Parse("DDDDDD"),
-        TextSize = 14,
+        TextSize = 18,
         Typeface = SKTypeface.FromFamilyName(
             "Consolas",
             weight: SKFontStyleWeight.SemiBold,
@@ -270,7 +270,7 @@ public class DriverTrackerDisplay(
                     var paint = new SKPaint
                     {
                         Color = SKColor.Parse(data.TeamColour),
-                        TextSize = 14,
+                        TextSize = 18,
                         Typeface = _boldTypeface,
                     };
 
@@ -278,7 +278,7 @@ public class DriverTrackerDisplay(
                     if (timingData.Latest.Lines[driverNumber].Line == state.CursorOffset)
                     {
                         var rectPaint = new SKPaint { Color = SKColor.Parse("FFFFFF") };
-                        canvas.DrawRoundRect(x - 6, y - 8, 46, 16, 4, 4, rectPaint);
+                        canvas.DrawRoundRect(x - 8, y - 10, 56, 20, 4, 4, rectPaint);
                     }
 
                     canvas.DrawCircle(x, y, 5, paint);

--- a/UndercutF1.Console/TerminalGraphics.cs
+++ b/UndercutF1.Console/TerminalGraphics.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace UndercutF1.Console;
 
 /// <summary>
@@ -15,6 +17,10 @@ public static class TerminalGraphics
     private const string ESCAPE_APC = "\u001B_G"; // Begins an Application Programming Command
     private const string ESCAPE_ST = "\u001B\\"; // String Terminator
 
+    private static readonly string EncodedFileName = Convert.ToBase64String(
+        Encoding.ASCII.GetBytes("drivertracker.png")
+    );
+
     /// <summary>
     /// Given a base64 encoded string of the PNG file,
     /// returns the control sequence for displaying that image in the terminal.
@@ -29,7 +35,7 @@ public static class TerminalGraphics
     {
         var args = new string[]
         {
-            "name=drivertracker",
+            $"name={EncodedFileName}",
             $"width={width}",
             $"height={height}",
             "preserveAspectRatio=0",


### PR DESCRIPTION
* After some experimentation, it seems that actually outputting a larger image reduces flickering (i.e., outputting a tiny image flickers a lot). maybe this means that the scaling of images to high resolution screens causes flickering?

Relates to #44