### PR TITLE
Dynamically scale track map

### DIFF
--- a/UndercutF1.Console/Display/InfoDisplay.cs
+++ b/UndercutF1.Console/Display/InfoDisplay.cs
@@ -30,8 +30,9 @@ public sealed class InfoDisplay(
 
             [bold]Terminal Diagnostics[/]
             [bold]TERM_PROGRAM:[/]        {Environment.GetEnvironmentVariable("TERM_PROGRAM")}
-            [bold]Kitty Supported:[/]     {terminalInfo.IsKittyProtocolSupported.Value}
-            [bold]iTerm2 Supported:[/]    {terminalInfo.IsITerm2ProtocolSupported.Value}
+            [bold]Window Size W/H:[/]     {terminalInfo.TerminalSize.Value?.Width}/{terminalInfo.TerminalSize.Value?.Height} ({(terminalInfo.TerminalSize.Value?.Height ?? 0) / Terminal.Size.Height})
+            [bold]Kitty Graphics:[/]      {terminalInfo.IsKittyProtocolSupported.Value}
+            [bold]iTerm2 Graphics:[/]     {terminalInfo.IsITerm2ProtocolSupported.Value}
             [bold]Synchronized Output:[/] {terminalInfo.IsSynchronizedOutputSupported.Value}
             [bold]Version:[/]             {ThisAssembly.AssemblyInformationalVersion}
             [bold]Runtime Identifier:[/]  {RuntimeInformation.RuntimeIdentifier}

--- a/UndercutF1.Console/TerminalInfoProvider.cs
+++ b/UndercutF1.Console/TerminalInfoProvider.cs
@@ -16,6 +16,9 @@ public sealed partial class TerminalInfoProvider
     [GeneratedRegex(@"\u001B\[\?2026;(\d+)\$y")]
     private static partial Regex TerminalSynchronizedOutputResponseRegex();
 
+    [GeneratedRegex(@"\u001B\[4;(\d+);(\d+)t")]
+    private static partial Regex TerminalSizeResponseRegex();
+
     /// <summary>
     /// Returns <see langword="true" /> if the current terminal supports the iTerm 2 Graphics Protocol.
     /// This is done in a very rudimentary way, and is by no means comprehensive.
@@ -37,12 +40,23 @@ public sealed partial class TerminalInfoProvider
     /// </summary>
     public Lazy<bool> IsSynchronizedOutputSupported { get; }
 
+    /// <summary>
+    /// Returns the size of the terminal in pizels. <c>null</c> if terminal size could not be determined.
+    /// </summary>
+    public Lazy<(int Height, int Width)?> TerminalSize { get; private set; }
+
     public TerminalInfoProvider(ILogger<TerminalInfoProvider> logger)
     {
         _logger = logger;
         IsITerm2ProtocolSupported = new Lazy<bool>(GetIsITerm2ProtocolSupported);
         IsKittyProtocolSupported = new Lazy<bool>(GetKittyProtocolSupported);
         IsSynchronizedOutputSupported = new Lazy<bool>(GetSynchronizedOutputSupported);
+        TerminalSize = new Lazy<(int, int)?>(GetTerminalSize);
+        Terminal.Resized += (_new) =>
+        {
+            TerminalSize = new Lazy<(int, int)?>(GetTerminalSize);
+            _ = TerminalSize.Value;
+        };
     }
 
     private bool GetIsITerm2ProtocolSupported()
@@ -132,7 +146,7 @@ public sealed partial class TerminalInfoProvider
                 Util.Sanitize(str)
             );
 
-            if (match.Success && !str.Contains("\u001B[?"))
+            if (match.Success && !str.Contains("\u001B[?6"))
             {
                 DiscardExtraResponse();
             }
@@ -143,6 +157,54 @@ public sealed partial class TerminalInfoProvider
         {
             _logger.LogError(e, "Failed to determine if terminal supports Synchronized Output");
             return false;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private (int Height, int Width)? GetTerminalSize()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(32);
+        try
+        {
+            // Send a DCS query to the terminal to query terminal size
+            Terminal.Out("\u001B[14t");
+            // Also send a device attributes escape code, so that there is always something to read from stdin
+            Terminal.Out("\u001B[c");
+
+            // Expected response: <ESC> [ ; <height> ; <width> t
+            Terminal.Read(buffer);
+            var str = Encoding.ASCII.GetString(buffer);
+            var match = TerminalSizeResponseRegex().Match(str);
+
+            var height = 0;
+            var width = 0;
+            _ =
+                match.Success
+                && match.Groups.Count == 3
+                && int.TryParse(match.Groups[1].Captures[0].Value, out height)
+                && int.TryParse(match.Groups[2].Captures[0].Value, out width);
+
+            _logger.LogDebug(
+                "Terminal Size (px): {Height}, {Width}: {Response}",
+                height,
+                width,
+                Util.Sanitize(str)
+            );
+
+            if (!str.Contains("\u001B[?"))
+            {
+                DiscardExtraResponse();
+            }
+
+            return height > 0 && width > 0 ? (height, width) : null;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to fetch terminal size in pixels");
+            return null;
         }
         finally
         {


### PR DESCRIPTION
Dynamically scales the track map to be as close as possible to the actual pixels available for the rendering. The reduction in need for the terminal to rescale the image appears to reduce flashing due to re-renders.

Relates to #44