### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,5 @@ jobs:
       run: dotnet build --no-restore -c Debug
     - name: Test
       run: dotnet test --no-build --verbosity normal -c Debug
+    - name: Typos
+      run: pipx run codespell --ignore-words-list=iterm --skip="*.json,*.txt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,3 @@ jobs:
       run: dotnet build --no-restore -c Debug
     - name: Test
       run: dotnet test --no-build --verbosity normal -c Debug
-    - name: Typos
-      run: pipx run codespell --ignore-words-list=iterm --skip="*.json,*.txt"

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The `Race Control` page shows all Race Control Messages for the session, along w
 
 ### Driver Tracker
 
-The `Driver Tracker` page shows a track map overlayed with selected drivers. Use the <kbd>▼</kbd>/<kbd>▲</kbd> `Cursor` actions to choose drivers, then use the <kbd>⏎</kbd> `Toggle Select` action to toggle the inclusion of the driver on the track map. The driver under the current cursor position will also be highlighted on the map, and timing gaps will switch to interval between that driver and all other drivers.
+The `Driver Tracker` page shows a track map overlaid with selected drivers. Use the <kbd>▼</kbd>/<kbd>▲</kbd> `Cursor` actions to choose drivers, then use the <kbd>⏎</kbd> `Toggle Select` action to toggle the inclusion of the driver on the track map. The driver under the current cursor position will also be highlighted on the map, and timing gaps will switch to interval between that driver and all other drivers.
 
 ![Driver Tracker Page](docs/screenshots/driver-tracker.png)
 
@@ -138,7 +138,7 @@ There are however some utilities that may need to be installed for some function
 - Team Radio audio playback uses [NetCoreAudio](https://github.com/mobiletechtracker/NetCoreAudio) for playback. See their [Prerequisites](https://github.com/mobiletechtracker/NetCoreAudio#prerequisites) for information if playback does not work.
   - On Linux, you need `mpg123` available on the `PATH`. For apt-based systems, you can install with `apt install mpg123`
   - Windows and Mac _should_ work out of the box
-- Team Radio transcription relies on FFmpeg and Whisper. Whisper models are downloaded on demand (after user confirmation) in the app. See the [FFmpeg download page](See <https://www.ffmpeg.org/download.html>) for details on how to instal.
+- Team Radio transcription relies on FFmpeg and Whisper. Whisper models are downloaded on demand (after user confirmation) in the app. See the [FFmpeg download page](See <https://www.ffmpeg.org/download.html>) for details on how to install.
   - On Linux apt-based systems, you can install with `apt install ffmpeg`
   - On Mac with brew, you can install with `brew install ffmpeg`
   - On Windows with WinGet, you can install with `winget install ffmpeg`

--- a/UndercutF1.Console/Display/DriverTrackerDisplay.cs
+++ b/UndercutF1.Console/Display/DriverTrackerDisplay.cs
@@ -337,7 +337,7 @@ public class DriverTrackerDisplay(
                 _errorPaint
             );
             canvas.DrawText($"Image Scale factor: {_transform.ScaleFactor}", 5, 100, _errorPaint);
-            canvas.DrawText($"Tranforms: {_transform}", 5, 120, _errorPaint);
+            canvas.DrawText($"Transforms: {_transform}", 5, 120, _errorPaint);
         }
 
         var imageData = surface.Snapshot().Encode();

--- a/UndercutF1.Console/Display/IDisplay.cs
+++ b/UndercutF1.Console/Display/IDisplay.cs
@@ -10,7 +10,7 @@ public interface IDisplay
 
     /// <summary>
     /// Called after the content from <see cref="GetContentAsync"/> has been drawn to the terminal.
-    /// Intended for use cases where overwriting whats been drawn is required, such as for terminal graphics.
+    /// Intended for use cases where overwriting what's been drawn is required, such as for terminal graphics.
     /// </summary>
     /// <returns>A task that completes when the drawing has completed</returns>
     Task PostContentDrawAsync() => Task.CompletedTask;

--- a/UndercutF1.Data/DateTimeProvider.cs
+++ b/UndercutF1.Data/DateTimeProvider.cs
@@ -19,7 +19,7 @@ public class DateTimeProvider(ILogger<DateTimeProvider> logger) : IDateTimeProvi
             var oldDelay = Delay;
 
             // To resume, we need to update the Delay to account for how long we've been paused for
-            // When resuming, calcualte what the delay should be based on the current time
+            // When resuming, calculate what the delay should be based on the current time
             Delay = DateTimeOffset.UtcNow - PausedAt.Value;
 
             logger.LogInformation(


### PR DESCRIPTION
% `pipx run codespell --ignore-words-list=iterm --skip="*.json,*.txt"`
```
./README.md:97: overlayed ==> overlaid
./README.md:141: instal ==> install
./UndercutF1.Console/Display/DriverTrackerDisplay.cs:340: Tranforms ==> Transforms
./UndercutF1.Console/Display/IDisplay.cs:13: whats ==> what's
./UndercutF1.Data/DateTimeProvider.cs:22: calcualte ==> calculate
```
% `pipx run codespell --ignore-words-list=iterm --skip="*.json,*.txt" --write-changes`
```
FIXED: ./README.md
FIXED: ./UndercutF1.Console/Display/DriverTrackerDisplay.cs
FIXED: ./UndercutF1.Console/Display/IDisplay.cs
FIXED: ./UndercutF1.Data/DateTimeProvider.cs
```
* https://pipx.pypa.io
* https://pypi.org/project/codespell