### PR TITLE
Use custom audio playback implementation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,6 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
-    <PackageVersion Include="NetCoreAudio" Version="2.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.0.0" />
     <PackageVersion Include="Serilog" Version="4.0.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />

--- a/README.md
+++ b/README.md
@@ -120,9 +120,7 @@ Charts on the right display how Gap to Leader and Lap Time for all selected driv
 
 Listen to team radio clips from anytime in the session, and use a local ML model (Whisper) to transcribe the audio on demand. Transcription accuracy is fairly low, depending on the that days audio quality and driver. Suggestions welcome for improving this!
 
-Audio playback prerequisites:
-
-- If on Linux, make sure you have `aplay` and `mpg123` installed. See [the NetCoreAudio Prerequisites for more details](https://github.com/mobiletechtracker/NetCoreAudio?tab=readme-ov-file#prerequisites)
+See [Prerequisites](#prerequisites) to ensure you are able to playback audio.
 
 ![Listen to and Transcribe Team Radio](docs/screenshots/team-radio.png)
 
@@ -135,9 +133,11 @@ Audio playback prerequisites:
 UndercutF1 tries to statically link as many dependencies as possible to make installation and usage easy.
 There are however some utilities that may need to be installed for some functionality:
 
-- Team Radio audio playback uses [NetCoreAudio](https://github.com/mobiletechtracker/NetCoreAudio) for playback. See their [Prerequisites](https://github.com/mobiletechtracker/NetCoreAudio#prerequisites) for information if playback does not work.
+- Team Radio audio playback uses platform-specific command-line executables to play audio files.
   - On Linux, you need `mpg123` available on the `PATH`. For apt-based systems, you can install with `apt install mpg123`
-  - Windows and Mac _should_ work out of the box
+  - On Mac, you need `afplay` available on the `PATH`. This should be installed by default.
+  - On Windows, we only support audio playback via FFmpeg (`ffplay`) - see below for installation instructions.
+  - On Linux/Mac, you can use the [`preferFfmpegPlayback` configuration](#configuration) to use `ffplay` instead of `mpg123`/`afplay`
 - Team Radio transcription relies on FFmpeg and Whisper. Whisper models are downloaded on demand (after user confirmation) in the app. See the [FFmpeg download page](See <https://www.ffmpeg.org/download.html>) for details on how to install.
   - On Linux apt-based systems, you can install with `apt install ffmpeg`
   - On Mac with brew, you can install with `brew install ffmpeg`
@@ -172,6 +172,8 @@ undercutf1
 ```
 
 This method is recommended as it is easy to keep the app updated using `brew upgrade`. Note that installing using `brew` will also install the `dotnet` formula. If you develop on your machine using the dotnet-sdk, and have the sdk installed through a non-brew method (e.g. directly from MS or via VSCode), I would recommend avoiding this installation method as the brew `dotnet` installation can conflict with your own installation due to differences in how `dotnet` is signed via brew.
+
+The brew installation method will also install all the mentioned [prerequisites](#prerequisites) for you.
 
 #### Install and run the standalone executable
 
@@ -276,13 +278,14 @@ UndercutF1 can be configured using either a simple `config.json` file, through t
 
 To view what configuration is currently being used, open the <kbd>I</kbd> `Info` screen when the app starts up.
 
-| JSON Path       | Command Line       | Environment Variable       | Description                                                                                                                                                               |
-| --------------- | ------------------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataDirectory` | `--data-directory` | `UNDERCUTF1_DATADIRECTORY` | The directory to which JSON timing data is read or written from. This directory is also where Whisper models will be stored (if downloaded) for team radio transcription. |
-| `logDirectory`  | `--log-directory`  | `UNDERCUTF1_LOGDIRECTORY`  | The directory to which logs are written to.                                                                                                                               |
-| `verbose`       | `-v\|--verbose`    | `UNDERCUTF1_VERBOSE`       | Whether verbose logging should be enabled. Default: `false`. Values: `true` or `false`.                                                                                   |
-| `apiEnabled`    | `--with-api`       | `UNDERCUTF1_APIENABLED`    | Whether the app should expose an API at <http://localhost:61937>. Default: `false`. Values: `true` or `false`.                                                            |
-| `notify`        | `--notify`         | `UNDERCUTF1_NOTIFY`        | Whether the app should sent audible BELs to your terminal when new race control messages are received. Default: `true`. Values: `true` or `false`.                        |
+| JSON Path              | Command Line       | Environment Variable              | Description                                                                                                                                                                               |
+| ---------------------- | ------------------ | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataDirectory`        | `--data-directory` | `UNDERCUTF1_DATADIRECTORY`        | The directory to which JSON timing data is read or written from. This directory is also where Whisper models will be stored (if downloaded) for team radio transcription.                 |
+| `logDirectory`         | `--log-directory`  | `UNDERCUTF1_LOGDIRECTORY`         | The directory to which logs are written to.                                                                                                                                               |
+| `verbose`              | `-v\|--verbose`    | `UNDERCUTF1_VERBOSE`              | Whether verbose logging should be enabled. Default: `false`. Values: `true` or `false`.                                                                                                   |
+| `apiEnabled`           | `--with-api`       | `UNDERCUTF1_APIENABLED`           | Whether the app should expose an API at <http://localhost:61937>. Default: `false`. Values: `true` or `false`.                                                                            |
+| `notify`               | `--notify`         | `UNDERCUTF1_NOTIFY`               | Whether the app should sent audible BELs to your terminal when new race control messages are received. Default: `true`. Values: `true` or `false`.                                        |
+| `preferFfmpegPlayback` | `--prefer-ffmpeg`  | `UNDERCUTF1_PREFERFFMPEGPLAYBACK` | Prefer the usage of `ffplay` for playing Team Radio on Mac/Linux, instead of afplay/mpg123 respectively. `ffplay` is always used on Windows. Default: `false`. Values: `true` or `false`. |
 
 ### Default Directories
 

--- a/UndercutF1.Console/Audio/AudioPlayer.cs
+++ b/UndercutF1.Console/Audio/AudioPlayer.cs
@@ -1,0 +1,73 @@
+namespace UndercutF1.Console.Audio;
+
+public class AudioPlayer(ILogger<AudioPlayer> logger)
+{
+    private ChildProcess? _process = null;
+
+    public bool Playing => !_process?.Completion.IsCompleted ?? false;
+
+    public bool Errored => _process?.Completion.IsFaulted ?? false;
+
+    public void Play(string filePath)
+    {
+        if (OperatingSystem.IsMacOS())
+        {
+            _process = Run("afplay", filePath);
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            _process = Run("mpg123", filePath, "--no-control");
+        }
+        else if (OperatingSystem.IsWindows())
+        {
+            _process = Run(
+                "ffplay",
+                filePath,
+                "-nodisp",
+                "-autoexit",
+                "-hide_banner",
+                "-loglevel error"
+            );
+        }
+        else
+        {
+            _process = null;
+            throw new InvalidOperationException(
+                "Unable to find a suitable audio playback method for the current operating system"
+            );
+        }
+    }
+
+    public void Stop()
+    {
+        if (_process is not null && !_process.Completion.IsCompleted)
+        {
+            logger.LogDebug("Stopping audio playback {PID}", _process.Id);
+        }
+        else
+        {
+            logger.LogDebug("No running process to stop");
+        }
+    }
+
+    private ChildProcess Run(string executable, params string[] args)
+    {
+        logger.LogDebug(
+            "Beginning audio playback of '{FileName}' with executable {Executable}",
+            args[0],
+            executable
+        );
+        var process = new ChildProcessBuilder()
+            .WithFileName(executable)
+            .WithArguments(args)
+            .WithThrowOnError(true)
+            .Run();
+
+        process.Completion.ContinueWith(LogProcessException, TaskContinuationOptions.OnlyOnFaulted);
+
+        return process;
+    }
+
+    private void LogProcessException(Task failed) =>
+        logger.LogError(failed.Exception, "Audio playback failed, bad exit code");
+}

--- a/UndercutF1.Console/Audio/AudioPlayer.cs
+++ b/UndercutF1.Console/Audio/AudioPlayer.cs
@@ -30,7 +30,7 @@ public class AudioPlayer(IOptions<LiveTimingOptions> options, ILogger<AudioPlaye
         }
         else if (OperatingSystem.IsLinux())
         {
-            _process = Run("mpg123", filePath, "--no-control");
+            _process = Run("mpg123", "--no-control", "--no-visual", "--quiet", filePath);
         }
         else
         {

--- a/UndercutF1.Console/Audio/AudioPlayer.cs
+++ b/UndercutF1.Console/Audio/AudioPlayer.cs
@@ -17,11 +17,12 @@ public class AudioPlayer(IOptions<LiveTimingOptions> options, ILogger<AudioPlaye
         {
             _process = Run(
                 "ffplay",
-                filePath,
                 "-nodisp",
                 "-autoexit",
                 "-hide_banner",
-                "-loglevel error"
+                "-loglevel",
+                "error",
+                filePath
             );
         }
         else if (OperatingSystem.IsMacOS())
@@ -57,9 +58,9 @@ public class AudioPlayer(IOptions<LiveTimingOptions> options, ILogger<AudioPlaye
     private ChildProcess Run(string executable, params string[] args)
     {
         logger.LogDebug(
-            "Beginning audio playback of '{FileName}' with executable {Executable}",
-            args[0],
-            executable
+            "Beginning audio playback with executable {Executable}, arguments: {Arguments}",
+            executable,
+            string.Join(' ', args)
         );
         var process = new ChildProcessBuilder()
             .WithFileName(executable)

--- a/UndercutF1.Console/CommandHandler.Root.cs
+++ b/UndercutF1.Console/CommandHandler.Root.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.OpenApi.Models;
+using UndercutF1.Console.Audio;
 using UndercutF1.Data;
 
 namespace UndercutF1.Console;
@@ -31,6 +32,7 @@ public static partial class CommandHandler
             .AddDisplays()
             .AddSingleton<INotifyHandler, NotifyHandler>()
             .AddSingleton<TerminalInfoProvider>()
+            .AddSingleton<AudioPlayer>()
             .AddHostedService(sp => sp.GetRequiredService<ConsoleLoop>());
 
         var options = builder.Configuration.Get<LiveTimingOptions>() ?? new();

--- a/UndercutF1.Console/CommandHandler.Root.cs
+++ b/UndercutF1.Console/CommandHandler.Root.cs
@@ -14,7 +14,8 @@ public static partial class CommandHandler
         DirectoryInfo? dataDirectory,
         DirectoryInfo? logDirectory,
         bool isVerbose,
-        bool? notifyEnabled
+        bool? notifyEnabled,
+        bool? preferFfmpeg
     )
     {
         var builder = GetBuilder(
@@ -22,7 +23,8 @@ public static partial class CommandHandler
             dataDirectory: dataDirectory,
             logDirectory: logDirectory,
             isVerbose: isVerbose,
-            notifyEnabled: notifyEnabled
+            notifyEnabled: notifyEnabled,
+            preferFfmpeg: preferFfmpeg
         );
 
         builder

--- a/UndercutF1.Console/CommandHandler.cs
+++ b/UndercutF1.Console/CommandHandler.cs
@@ -14,6 +14,7 @@ public static partial class CommandHandler
         DirectoryInfo? logDirectory = null,
         bool isVerbose = false,
         bool? notifyEnabled = null,
+        bool? preferFfmpeg = null,
         bool useConsoleLogging = false
     )
     {
@@ -39,6 +40,13 @@ public static partial class CommandHandler
         if (notifyEnabled is not null)
         {
             commandLineOpts.Add(nameof(LiveTimingOptions.Notify), notifyEnabled.ToString());
+        }
+        if (preferFfmpeg is not null)
+        {
+            commandLineOpts.Add(
+                nameof(LiveTimingOptions.PreferFfmpegPlayback),
+                preferFfmpeg.ToString()
+            );
         }
 
         builder

--- a/UndercutF1.Console/Input/PlayTeamRadioInputHandler.cs
+++ b/UndercutF1.Console/Input/PlayTeamRadioInputHandler.cs
@@ -1,10 +1,13 @@
-using NetCoreAudio;
+using UndercutF1.Console.Audio;
 using UndercutF1.Data;
 
 namespace UndercutF1.Console;
 
-public sealed class PlayTeamRadioInputHandler(State state, TeamRadioProcessor teamRadio)
-    : IInputHandler
+public sealed class PlayTeamRadioInputHandler(
+    AudioPlayer audioPlayer,
+    State state,
+    TeamRadioProcessor teamRadio
+) : IInputHandler
 {
     public bool IsEnabled => true;
 
@@ -12,20 +15,21 @@ public sealed class PlayTeamRadioInputHandler(State state, TeamRadioProcessor te
 
     public ConsoleKey[] Keys => [ConsoleKey.Enter];
 
-    public string Description => _player.Playing ? "[olive]⏹ Stop[/]" : "► Play Radio";
+    public string Description =>
+        audioPlayer.Playing ? "[olive]⏹ Stop[/]"
+        : audioPlayer.Errored ? "[red]Playback Error[/]"
+        : "► Play Radio";
 
     public int Sort => 40;
-
-    private readonly Player _player = new Player();
 
     public async Task ExecuteAsync(
         ConsoleKeyInfo consoleKeyInfo,
         CancellationToken cancellationToken = default
     )
     {
-        if (_player.Playing)
+        if (audioPlayer.Playing)
         {
-            await _player.Stop();
+            audioPlayer.Stop();
         }
         else
         {
@@ -40,6 +44,6 @@ public sealed class PlayTeamRadioInputHandler(State state, TeamRadioProcessor te
             radio.Key,
             cancellationToken
         );
-        await _player.Play(destFileName);
+        audioPlayer.Play(destFileName);
     }
 }

--- a/UndercutF1.Console/Program.cs
+++ b/UndercutF1.Console/Program.cs
@@ -26,12 +26,17 @@ var notifyOption = new Option<bool?>(
     "--notify",
     "Whether audible BELs are sent to your terminal when new race control messages are received"
 );
+var preferFfmpegOption = new Option<bool?>(
+    "--prefer-ffmpeg",
+    "Prefer the usage of `ffplay` for playing Team Radio on Mac/Linux, instead of afplay/mpg123. `ffplay` is always used on Windows"
+);
 
 rootCommand.AddGlobalOption(isVerboseOption);
 rootCommand.AddGlobalOption(isApiEnabledOption);
 rootCommand.AddGlobalOption(dataDirectoryOption);
 rootCommand.AddGlobalOption(logDirectoryOption);
 rootCommand.AddGlobalOption(notifyOption);
+rootCommand.AddGlobalOption(preferFfmpegOption);
 
 rootCommand.SetHandler(
     CommandHandler.Root,
@@ -39,7 +44,8 @@ rootCommand.SetHandler(
     dataDirectoryOption,
     logDirectoryOption,
     isVerboseOption,
-    notifyOption
+    notifyOption,
+    preferFfmpegOption
 );
 
 var importCommand = new Command(

--- a/UndercutF1.Console/UndercutF1.Console.csproj
+++ b/UndercutF1.Console/UndercutF1.Console.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options" />
-    <PackageReference Include="NetCoreAudio" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Sinks.File" />

--- a/UndercutF1.Data/Options/LiveTimingOptions.cs
+++ b/UndercutF1.Data/Options/LiveTimingOptions.cs
@@ -52,6 +52,13 @@ public record LiveTimingOptions
     /// </summary>
     public bool Notify { get; set; } = true;
 
+    /// <summary>
+    /// Prefer to use FFmpeg (<c>ffplay</c>) for audio playback (e.g. Team Radio) instead of more native options
+    /// such as <c>mpg123</c> or <c>afplay</c>. FFmpeg is always used on Windows.
+    /// Defaults to <see langword="false"/> .
+    /// </summary>
+    public bool PreferFfmpegPlayback { get; set; } = false;
+
     private static string GetConfigFilePath()
     {
         if (OperatingSystem.IsWindows())


### PR DESCRIPTION
Relates to #25.

Use our own callouts to `afplay`/`mpg123`/`ffplay` to playback team radio, instead of relying on `NetCoreAudio`. This way we can prevent terminal corruption, and have more control over error and playback states.

Adds new configuration to allow users to prefer the use of `ffplay` instead of `afplay`/`mpg123` on Mac/Linux. This should help give control to those who face any issues. `ffplay` is always used on Windows.