### PR TITLE
Show mini sectors during qualifying

### DIFF
--- a/UndercutF1.Data/AutoMapper/TimingDataPointConfiguration.cs
+++ b/UndercutF1.Data/AutoMapper/TimingDataPointConfiguration.cs
@@ -20,6 +20,11 @@ public class TimingDataPointConfiguration : Profile
             Dictionary<string, TimingDataPoint.Driver.LapSectorTime>
         >()
             .ConvertUsingDictionaryMerge();
+        CreateMap<
+            Dictionary<int, TimingDataPoint.Driver.LapSectorTime.Segment>,
+            Dictionary<int, TimingDataPoint.Driver.LapSectorTime.Segment>
+        >()
+            .ConvertUsingDictionaryMerge();
 
         CreateMap<TimingDataPoint.Driver, TimingDataPoint.Driver>()
             .ForAllMembers(opts => opts.Condition((_, _, member) => member != null));
@@ -28,6 +33,12 @@ public class TimingDataPointConfiguration : Profile
             .ForAllMembers(opts => opts.Condition((_, _, member) => member != null));
 
         CreateMap<TimingDataPoint.Driver.LapSectorTime, TimingDataPoint.Driver.LapSectorTime>()
+            .ForAllMembers(opts => opts.Condition((_, _, member) => member != null));
+
+        CreateMap<
+            TimingDataPoint.Driver.LapSectorTime.Segment,
+            TimingDataPoint.Driver.LapSectorTime.Segment
+        >()
             .ForAllMembers(opts => opts.Condition((_, _, member) => member != null));
     }
 }

--- a/UndercutF1.Data/Client/TimingService.cs
+++ b/UndercutF1.Data/Client/TimingService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -183,7 +184,14 @@ public class TimingService(
                 {
                     if (line?["Sectors"] is null)
                         continue;
-                    line["Sectors"] = ArrayToIndexedDictionary(line["Sectors"]!);
+                    line["Sectors"] = ArrayToIndexedDictionary(line["Sectors"]);
+
+                    foreach (var (key, sector) in line["Sectors"]!.AsObject())
+                    {
+                        if (sector?["Segments"] is null)
+                            continue;
+                        sector["Segments"] = ArrayToIndexedDictionary(sector["Segments"]);
+                    }
                 }
                 SendToProcessor<TimingDataPoint>(json);
                 break;

--- a/UndercutF1.Data/Models/TimingDataPoints/TimingDataPoint.cs
+++ b/UndercutF1.Data/Models/TimingDataPoints/TimingDataPoint.cs
@@ -1,3 +1,5 @@
+using Whisper.net;
+
 namespace UndercutF1.Data;
 
 public sealed record TimingDataPoint : ILiveTimingDataPoint
@@ -69,6 +71,12 @@ public sealed record TimingDataPoint : ILiveTimingDataPoint
             public string? Value { get; set; }
             public bool? OverallFastest { get; set; }
             public bool? PersonalFastest { get; set; }
+            public Dictionary<int, Segment>? Segments { get; set; }
+
+            public sealed record Segment
+            {
+                public StatusFlags? Status { get; set; }
+            }
         }
 
         public sealed record BestLap
@@ -80,13 +88,22 @@ public sealed record TimingDataPoint : ILiveTimingDataPoint
         [Flags]
         public enum StatusFlags
         {
-            Unknown16 = 16,
-            Unknown64 = 64,
+            PersonalBest = 1,
+            OverallBest = 2,
+            /// <summary>
+            /// Went through this mini sector in the pit lane
+            /// </summary>
+            PitLane = 16,
 
             /// <summary>
             /// Set when the driver passes the chequered flag in quali or race sessions
             /// </summary>
             ChequeredFlag = 1024,
+
+            /// <summary>
+            /// Segment completed. If this is the only flag set, means a yellow segment.
+            /// </summary>
+            SegmentComplete = 2048,
         }
     }
 }


### PR DESCRIPTION
During non-race sessions, display the mini sector status (yellow, green, purple) on the sector time until the second has completed.