### PR TITLE
Implement a basic clock control API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Feature Highlights:
 - [Logging](#logging)
 - [Alternate Key Binds](#alternate-key-binds)
 - [Data Recording and Replay](#data-recording-and-replay)
+- [API](#api)
+  - [Control API](#control-api)
+  - [Data API](#data-api)
 - [Notice](#notice)
 
 ## Inspiration
@@ -343,6 +346,27 @@ All events received by the live timing client will be written to the configured 
 - `live.txt` contains an append-log of every message received in the stream
 
 Both of these files are required for future simulations/replays. The `IJsonTimingClient` supports loading these files and processing them in the same way live data would be. Data points will be replayed in real time, using an adjustable delay.
+
+## API
+
+undercut-f1 ships with a simple HTTP API which allows for local integrations with your timing screen/data. [see Configuration for details on how to enable the API](#configuration). Once enabled, visit [the Swagger UI page at http://localhost:61937/swagger/index.html](http://localhost:61937/swagger/index.html) to see what APIs are available. This is an easy place to test the API and see what kind of data you get, and also the schema.
+
+### Control API
+
+The Control API `POST http://localhost:61937/control` allows you to issue control commands to the currently running session to, for example, pause the session clock.
+
+```sh
+# Pause the session clock
+curl -H "content-type:application/json" -X POST http://localhost:61937/control -d '{"operation": "PauseClock"}'
+# Resume the session clock
+curl -H "content-type:application/json" -X POST http://localhost:61937/control -d '{"operation": "ResumeClock"}'
+# Toggle (Play/Pause) the session clock
+curl -H "content-type:application/json" -X POST http://localhost:61937/control -d '{"operation": "ToggleClock"}'
+```
+
+### Data API
+
+The Data API `POST http://localhost:61938/data/<data-type>/latest` allow you to fetch the current raw timing data state. Take a look at the Swagger schema, and the [source model files](./UndercutF1.Data/Models/TimingDataPoints/) to understand more about what data is available for each timing `data-type`.
 
 ## Notice
 

--- a/UndercutF1.Console/Api/ControlEndpoints.cs
+++ b/UndercutF1.Console/Api/ControlEndpoints.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Mvc;
+using UndercutF1.Data;
+
+namespace UndercutF1.Console.Api;
+
+public enum ControlOperation
+{
+    PauseClock,
+    ResumeClock,
+    ToggleClock,
+}
+
+public sealed record ControlRequest(ControlOperation operation);
+
+public enum ControlErrorCode
+{
+    NoRunningSession,
+    UnknwonOperation,
+};
+
+public sealed record ControlError(ControlErrorCode errorCode)
+{
+    public string errorMessage =>
+        errorCode switch
+        {
+            ControlErrorCode.NoRunningSession => "No session is currently running",
+            ControlErrorCode.UnknwonOperation => "Unknown operation requested",
+            _ => "Unknwon error",
+        };
+}
+
+public static class ControlEndpoints
+{
+    public static WebApplication MapControlEndpoints(this WebApplication app)
+    {
+        app.MapPost("/control", ControlApiEndpoint)
+            .WithDescription(
+                "Issues control commands to the currently running session. These commands allow you to, for example, start or stop the session clock to synchronize your timing screen with another service"
+            )
+            .WithTags("Control")
+            .Produces(StatusCodes.Status200OK)
+            .Produces<ControlError>(StatusCodes.Status400BadRequest);
+
+        return app;
+    }
+
+    public static IResult ControlApiEndpoint(
+        [FromBody] ControlRequest request,
+        SessionInfoProcessor sessionInfo,
+        IDateTimeProvider dateTimeProvider
+    )
+    {
+        if (sessionInfo.Latest.Name is null)
+        {
+            return Results.BadRequest(new ControlError(ControlErrorCode.NoRunningSession));
+        }
+
+        if (!Enum.IsDefined(request.operation))
+        {
+            return Results.BadRequest(new ControlError(ControlErrorCode.UnknwonOperation));
+        }
+
+        switch (request.operation)
+        {
+            case ControlOperation.PauseClock when !dateTimeProvider.IsPaused:
+                dateTimeProvider.TogglePause();
+                break;
+            case ControlOperation.ResumeClock when dateTimeProvider.IsPaused:
+                dateTimeProvider.TogglePause();
+                break;
+            case ControlOperation.ToggleClock:
+                dateTimeProvider.TogglePause();
+                break;
+        }
+
+        return Results.Ok();
+    }
+}

--- a/UndercutF1.Console/Api/TimingEndpoints.cs
+++ b/UndercutF1.Console/Api/TimingEndpoints.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using UndercutF1.Data;
 
-namespace UndercutF1.Console;
+namespace UndercutF1.Console.Api;
 
 public static class TimingEndpoints
 {
@@ -19,22 +19,24 @@ public static class TimingEndpoints
             .MapLatestDataEndpoint<WeatherProcessor, WeatherDataPoint>();
 
         app.MapGet(
-            "/data/TimingData/laps/{lapNumber}",
-            ([FromRoute] int lapNumber, TimingDataProcessor processor) =>
-            {
-                return processor.DriversByLap.TryGetValue(lapNumber, out var data)
-                    ? TypedResults.Ok(data)
-                    : Results.NotFound();
-            }
-        );
+                "/data/TimingData/laps/{lapNumber}",
+                ([FromRoute] int lapNumber, TimingDataProcessor processor) =>
+                {
+                    return processor.DriversByLap.TryGetValue(lapNumber, out var data)
+                        ? TypedResults.Ok(data)
+                        : Results.NotFound();
+                }
+            )
+            .WithTags("Timing Data");
 
         app.MapGet(
-            "/data/TimingData/laps/best",
-            (TimingDataProcessor processor) =>
-            {
-                return TypedResults.Ok(processor.BestLaps);
-            }
-        );
+                "/data/TimingData/laps/best",
+                (TimingDataProcessor processor) =>
+                {
+                    return TypedResults.Ok(processor.BestLaps);
+                }
+            )
+            .WithTags("Timing Data");
 
         return app;
     }
@@ -45,12 +47,13 @@ public static class TimingEndpoints
     {
         var dataPoint = new T();
         app.MapGet(
-            $"/data/{dataPoint.LiveTimingDataType}/latest",
-            (TProcessor processor) =>
-            {
-                return TypedResults.Ok(processor.Latest);
-            }
-        );
+                $"/data/{dataPoint.LiveTimingDataType}/latest",
+                (TProcessor processor) =>
+                {
+                    return TypedResults.Ok(processor.Latest);
+                }
+            )
+            .WithTags("Timing Data");
         return app;
     }
 }


### PR DESCRIPTION
Relates to #62, adds a new control API `POST http://localhost:61937/control` which allows you to pause or resume the session clock. This allows for manual integrations with third-party systems to control the currently running timing screen.

This is the initial implementation for #62, next up will be an option for more direct integrations with third-party services like Kodi, so you don't have to build your own.