### PR TITLE
Fix info command

### DIFF
--- a/UndercutF1.Console/CommandHandler.Root.cs
+++ b/UndercutF1.Console/CommandHandler.Root.cs
@@ -39,7 +39,6 @@ public static partial class CommandHandler
             .AddSingleton<INotifyHandler, NotifyHandler>()
             .AddSingleton<TerminalInfoProvider>()
             .AddSingleton<AudioPlayer>()
-            .AddSingleton<WebSocketSynchroniser>()
             .AddHostedService(sp => sp.GetRequiredService<ConsoleLoop>())
             .AddHostedService(sp => sp.GetRequiredService<WebSocketSynchroniser>());
 

--- a/UndercutF1.Console/CommandHandler.cs
+++ b/UndercutF1.Console/CommandHandler.cs
@@ -2,6 +2,7 @@ using InMemLogger;
 using Serilog;
 using Serilog.Events;
 using TextCopy;
+using UndercutF1.Console.ExternalPlayerSync;
 using UndercutF1.Console.Graphics;
 using UndercutF1.Data;
 
@@ -104,6 +105,7 @@ public static partial class CommandHandler
             })
             .Configure<Options>(builder.Configuration)
             .AddLiveTiming(builder.Configuration)
+            .AddSingleton<WebSocketSynchroniser>()
             .InjectClipboard();
 
         builder.WebHost.UseServer(new NullServer());


### PR DESCRIPTION
`info` command stopped working since the External Play Sync changes (embarrassing), so fixing the dependencies to make it work again.