### PR TITLE
Only update terminal graphics if they've changed since the last draw

### DIFF
--- a/UndercutF1.Console/ConsoleLoop.cs
+++ b/UndercutF1.Console/ConsoleLoop.cs
@@ -78,6 +78,8 @@ public class ConsoleLoop(
                     );
                 }
 
+                var shouldDraw = _previousDraw != output;
+
                 if (_previousDraw != output)
                 {
                     await Terminal.OutAsync(output, cancellationToken);
@@ -86,7 +88,7 @@ public class ConsoleLoop(
 
                 if (display is not null)
                 {
-                    await display.PostContentDrawAsync();
+                    await display.PostContentDrawAsync(shouldDraw);
                 }
             }
             catch (Exception ex)

--- a/UndercutF1.Console/Display/DriverTrackerDisplay.cs
+++ b/UndercutF1.Console/Display/DriverTrackerDisplay.cs
@@ -63,6 +63,7 @@ public class DriverTrackerDisplay : IDisplay
     private TransformFactors? _transform = null;
 
     private string[] _trackMapControlSequence = [];
+    private string[] _previousTrackMapControlSequence = [];
 
     public DriverTrackerDisplay(
         State state,
@@ -428,12 +429,19 @@ public class DriverTrackerDisplay : IDisplay
     }
 
     /// <inheritdoc />
-    public async Task PostContentDrawAsync()
+    public async Task PostContentDrawAsync(bool shouldDraw)
     {
         await Terminal.OutAsync(ControlSequences.MoveCursorTo(TOP_OFFSET, LEFT_OFFSET));
-        foreach (var sequence in _trackMapControlSequence)
+
+        var hasChanged = !_previousTrackMapControlSequence.SequenceEqual(_trackMapControlSequence);
+        // Only draw if we need to, or if the drawing has changed
+        if (shouldDraw || !hasChanged)
         {
-            await Terminal.OutAsync(sequence);
+            foreach (var sequence in _trackMapControlSequence)
+            {
+                await Terminal.OutAsync(sequence);
+                _previousTrackMapControlSequence = _trackMapControlSequence;
+            }
         }
     }
 

--- a/UndercutF1.Console/Display/IDisplay.cs
+++ b/UndercutF1.Console/Display/IDisplay.cs
@@ -12,6 +12,7 @@ public interface IDisplay
     /// Called after the content from <see cref="GetContentAsync"/> has been drawn to the terminal.
     /// Intended for use cases where overwriting what's been drawn is required, such as for terminal graphics.
     /// </summary>
+    /// <param name="forceDraw">If true, this function should result in a draw being made, ignoring any optimisation logic</param>
     /// <returns>A task that completes when the drawing has completed</returns>
-    Task PostContentDrawAsync() => Task.CompletedTask;
+    Task PostContentDrawAsync(bool forceDraw) => Task.CompletedTask;
 }

--- a/UndercutF1.Console/Display/TimingHistoryDisplay.cs
+++ b/UndercutF1.Console/Display/TimingHistoryDisplay.cs
@@ -61,6 +61,7 @@ public class TimingHistoryDisplay(
     };
 
     private string[] _chartPanelControlSequence = [];
+    private string[] _previousSequence = [];
 
     public Task<IRenderable> GetContentAsync()
     {
@@ -74,12 +75,19 @@ public class TimingHistoryDisplay(
     }
 
     /// <inheritdoc />
-    public async Task PostContentDrawAsync()
+    public async Task PostContentDrawAsync(bool shouldDraw)
     {
         await Terminal.OutAsync(ControlSequences.MoveCursorTo(0, LEFT_OFFSET));
-        foreach (var sequence in _chartPanelControlSequence)
+
+        // Only draw if we need to, or if the drawing has changed
+        var hasChanged = !_previousSequence.SequenceEqual(_chartPanelControlSequence);
+        if (shouldDraw || hasChanged)
         {
-            await Terminal.OutAsync(sequence);
+            foreach (var sequence in _chartPanelControlSequence)
+            {
+                await Terminal.OutAsync(sequence);
+                _previousSequence = _chartPanelControlSequence;
+            }
         }
     }
 

--- a/UndercutF1.Console/Input/EscapeInputHandler.cs
+++ b/UndercutF1.Console/Input/EscapeInputHandler.cs
@@ -23,11 +23,13 @@ public class EscapeInputHandler(State state) : IInputHandler
             _ => "Back",
         };
 
-    public Task ExecuteAsync(
+    public async Task ExecuteAsync(
         ConsoleKeyInfo consoleKeyInfo,
         CancellationToken cancellationToken = default
     )
     {
+        await Terminal.OutAsync(ControlSequences.ClearScreen(ClearMode.Full), cancellationToken);
+
         state.CurrentScreen = state.CurrentScreen switch
         {
             Screen.Main => Screen.Shutdown,
@@ -38,7 +40,5 @@ public class EscapeInputHandler(State state) : IInputHandler
         };
 
         state.CursorOffset = 0;
-
-        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
In a bid to reduce graphics flashing and improve efficiency, we now only send the graphics sequences to the terminal if it has changed since the last draw. We currently need to still end it if the background screen as been redrawn, because that causes the old graphic to be removed.

Relates to #71 