### PR TITLE
Use PitLaneTimeCollection instead of PitStopSeries to show pit lane times

### DIFF
--- a/UndercutF1.Console/Input/DelayInputHandler.cs
+++ b/UndercutF1.Console/Input/DelayInputHandler.cs
@@ -14,6 +14,7 @@ public class DelayInputHandler(IDateTimeProvider dateTimeProvider) : IInputHandl
             Screen.TimingTower,
             Screen.TimingHistory,
             Screen.TyreStints,
+            Screen.DebugData,
         ];
 
     public ConsoleKey[] DisplayKeys => [ConsoleKey.N, ConsoleKey.M];

--- a/UndercutF1.Console/Program.cs
+++ b/UndercutF1.Console/Program.cs
@@ -149,7 +149,7 @@ rootCommand.Subcommands.Add(imageCommand);
 var loginCommand = new Command(
     "login",
     """
-    Login to your Formula 1 account to unlock all feature of undercut-f1.
+    Login to your Formula 1 account to unlock all data feeds (like the driver tracker).
     """
 )
 {

--- a/UndercutF1.Console/State.cs
+++ b/UndercutF1.Console/State.cs
@@ -1,5 +1,3 @@
-using Spectre.Console;
-
 namespace UndercutF1.Console;
 
 public record State

--- a/UndercutF1.Data/Client/TimingService.cs
+++ b/UndercutF1.Data/Client/TimingService.cs
@@ -130,6 +130,11 @@ public class TimingService(
                 DateTimeOffset.UtcNow
             );
             ProcessData("PitStopSeries", obj["PitStopSeries"]?.ToString(), DateTimeOffset.UtcNow);
+            ProcessData(
+                "PitLaneTimeCollection",
+                obj["PitLaneTimeCollection"]?.ToString(),
+                DateTimeOffset.UtcNow
+            );
         }
         catch (Exception ex)
         {
@@ -248,6 +253,9 @@ public class TimingService(
                     );
                 }
                 SendToProcessor<PitStopSeriesDataPoint>(json);
+                break;
+            case LiveTimingDataType.PitLaneTimeCollection:
+                SendToProcessor<PitLaneTimeCollectionDataPoint>(json);
                 break;
         }
     }

--- a/UndercutF1.Data/DataImporter.cs
+++ b/UndercutF1.Data/DataImporter.cs
@@ -31,7 +31,9 @@ public sealed class DataImporter(
         "TimingData",
         "ChampionshipPrediction",
         "TeamRadio",
+        "PitLaneTimeCollection",
         "PitStopSeries",
+        "PitStop",
     ];
 
     private static readonly string[] _nonRaceTopics =
@@ -50,7 +52,9 @@ public sealed class DataImporter(
         "SessionData",
         "TimingData",
         "TeamRadio",
+        "PitLaneTimeCollection",
         "PitStopSeries",
+        "PitStop",
     ];
 
     /// <inheritdoc />

--- a/UndercutF1.Data/Models/Extensions/TimingAppDataPointExtensions.cs
+++ b/UndercutF1.Data/Models/Extensions/TimingAppDataPointExtensions.cs
@@ -1,0 +1,25 @@
+namespace UndercutF1.Data;
+
+public static class TimingAppDataPointExtensions
+{
+    public static Dictionary<string, TimingAppDataPoint.Driver> GetOrderedLines(
+        this TimingAppDataPoint data
+    ) => data.Lines.OrderBy(x => x.Value.Line).ToDictionary(x => x.Key, x => x.Value);
+
+    /// <summary>
+    /// Calculates how many laps the stint lasted
+    /// </summary>
+    public static int GetStintDuration(this TimingAppDataPoint.Driver.Stint stint) =>
+        (stint.TotalLaps - stint.StartLaps) ?? 0;
+
+    /// <summary>
+    /// Gets the lap number that the selected stint started on
+    /// </summary>
+    public static int GetPitLapForStint(
+        this Dictionary<string, TimingAppDataPoint.Driver.Stint> stints,
+        string stintNumber
+    ) =>
+        stints
+            .TakeWhile((kv) => int.Parse(kv.Key) < int.Parse(stintNumber))
+            .Sum(x => x.Value.GetStintDuration()) + 1;
+}

--- a/UndercutF1.Data/Models/Extensions/TimingDataPointExtensions.cs
+++ b/UndercutF1.Data/Models/Extensions/TimingDataPointExtensions.cs
@@ -8,10 +8,6 @@ public static class TimingDataPointExtensions
         this TimingDataPoint data
     ) => data.Lines.OrderBy(x => x.Value.Line).ToDictionary(x => x.Key, x => x.Value);
 
-    public static Dictionary<string, TimingAppDataPoint.Driver> GetOrderedLines(
-        this TimingAppDataPoint data
-    ) => data.Lines.OrderBy(x => x.Value.Line).ToDictionary(x => x.Key, x => x.Value);
-
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Style",
         "IDE0046:Convert to conditional expression",

--- a/UndercutF1.Data/Models/LiveTimingDataType.cs
+++ b/UndercutF1.Data/Models/LiveTimingDataType.cs
@@ -19,4 +19,5 @@ public enum LiveTimingDataType
     ChampionshipPrediction,
     TeamRadio,
     PitStopSeries,
+    PitLaneTimeCollection,
 }

--- a/UndercutF1.Data/Models/TimingDataPoints/PitLaneTimeCollectionDataPoint.cs
+++ b/UndercutF1.Data/Models/TimingDataPoints/PitLaneTimeCollectionDataPoint.cs
@@ -1,0 +1,17 @@
+namespace UndercutF1.Data;
+
+// {"Type":"PitLaneTimeCollection","Json":{"PitTimes":{"1":{"RacingNumber":"1","Duration":"","Lap":"5"}}},"DateTime":"2025-09-05T15:16:10.363+00:00"}
+public sealed record PitLaneTimeCollectionDataPoint : ILiveTimingDataPoint
+{
+    /// <inheritdoc />
+    public LiveTimingDataType LiveTimingDataType => LiveTimingDataType.PitLaneTimeCollection;
+
+    public Dictionary<string, PitTime> PitTimes { get; set; } = new();
+    public Dictionary<string, List<PitTime>> PitTimesList { get; set; } = new();
+
+    public sealed record PitTime
+    {
+        public string? Duration { get; set; }
+        public string? Lap { get; set; }
+    }
+}

--- a/UndercutF1.Data/Models/TimingDataPoints/TimingAppDataPoint.cs
+++ b/UndercutF1.Data/Models/TimingDataPoints/TimingAppDataPoint.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-
 namespace UndercutF1.Data;
 
 /// <summary>

--- a/UndercutF1.Data/Processors/PitLaneTimeCollectionProcessor.cs
+++ b/UndercutF1.Data/Processors/PitLaneTimeCollectionProcessor.cs
@@ -1,0 +1,23 @@
+namespace UndercutF1.Data;
+
+public class PitLaneTimeCollectionProcessor() : IProcessor<PitLaneTimeCollectionDataPoint>
+{
+    public PitLaneTimeCollectionDataPoint Latest { get; private set; } = new();
+
+    public void Process(PitLaneTimeCollectionDataPoint data)
+    {
+        foreach (var (driverNumber, pitTime) in data.PitTimes)
+        {
+            if (Latest.PitTimesList.TryGetValue(driverNumber, out var existing))
+            {
+                existing.Add(pitTime);
+            }
+            else
+            {
+                Latest.PitTimesList.Add(driverNumber, [pitTime]);
+            }
+
+            Latest.PitTimes[driverNumber] = pitTime;
+        }
+    }
+}


### PR DESCRIPTION
Closes #75 (not identical functionality, but I don't think pit stop times will be available now).

Uses the `PitLaneTimeCollection` feed to show how long the driver spent in the pit lane for their pit stops, in the Tyre Stint timing screen.

Also uses stint-based logic to show which lap drivers pit on, instead of relying on a data feed.