### PR TITLE
Fix incorrect thread state for WebView on Windows

### DIFF
--- a/UndercutF1.Console/Program.cs
+++ b/UndercutF1.Console/Program.cs
@@ -170,4 +170,15 @@ var logoutCommand = new Command(
 logoutCommand.SetAction(res => CommandHandler.LogoutOfFormula1Account());
 rootCommand.Subcommands.Add(logoutCommand);
 
-await new CommandLineConfiguration(rootCommand).InvokeAsync(args);
+var commandConfiguration = new CommandLineConfiguration(rootCommand);
+var parseResult = commandConfiguration.Parse(args);
+
+if (OperatingSystem.IsWindows() && parseResult.CommandResult.Command.Name == "login")
+{
+    // To allow the login command to spawn a webview, the main threads apartment state must be set to STA.
+    // For some reason, that is only allowed after setting it to Unknown first.
+    Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
+    Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
+}
+
+await parseResult.InvokeAsync();


### PR DESCRIPTION
Relates to #93 (not yet a complete fix, need webview_csharp to also be fixed)

For the WebView to be allowed to spawn, the thread state _must_ be STA otherwise it will fail (silently...)

Docs:
https://github.com/webview/webview_csharp/blob/3233b1235fbc0365ff03296703d947da5e64d5e8/README.md?plain=1#L34-L42