### PR TITLE
Upgrade webview to resolve windows loopback issue

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Serilog" Version="4.0.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageVersion Include="SharpWebview" Version="0.11.2" />
+    <PackageVersion Include="SharpWebview" Version="0.11.3" />
     <PackageVersion Include="SkiaSharp" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="2.88.9" />


### PR DESCRIPTION
Relates to #93.

With this package upgrade, the WebView on Windows should open correctly to allow a guided login experience.