### PR TITLE
Prefer iTerm graphics protocol when enabled

### DIFF
--- a/UndercutF1.Console/Display/DriverTrackerDisplay.cs
+++ b/UndercutF1.Console/Display/DriverTrackerDisplay.cs
@@ -392,31 +392,7 @@ public class DriverTrackerDisplay : IDisplay
         }
 
         var image = surface.Snapshot();
-
-        if (_terminalInfo.IsKittyProtocolSupported.Value)
-        {
-            var imageData = image.Encode();
-            var base64 = Convert.ToBase64String(imageData.AsSpan());
-            return
-            [
-                TerminalGraphics.KittyGraphicsSequenceDelete(),
-                .. TerminalGraphics.KittyGraphicsSequence(windowHeight, windowWidth, base64),
-            ];
-        }
-        else if (_terminalInfo.IsITerm2ProtocolSupported.Value)
-        {
-            var imageData = image.Encode();
-            var base64 = Convert.ToBase64String(imageData.AsSpan());
-            return [TerminalGraphics.ITerm2GraphicsSequence(windowHeight, windowWidth, base64)];
-        }
-        else if (_terminalInfo.IsSixelSupported.Value)
-        {
-            var bitmap = SKBitmap.FromImage(image);
-            var sixelData = Sixel.ImageToSixel(bitmap.Pixels, bitmap.Width);
-            return [TerminalGraphics.SixelGraphicsSequence(sixelData)];
-        }
-
-        return ["Unexpected error, shouldn't have got here. Please report!"];
+        return image.ToGraphicsSequence(_terminalInfo, windowHeight, windowWidth);
     }
 
     private TransformFactors GetTransformFactors()

--- a/UndercutF1.Console/Display/InfoDisplay.cs
+++ b/UndercutF1.Console/Display/InfoDisplay.cs
@@ -37,8 +37,8 @@ public sealed class InfoDisplay(
             [bold]Terminal Diagnostics[/]
             [bold]TERM_PROGRAM:[/]        {Environment.GetEnvironmentVariable("TERM_PROGRAM")}
             [bold]Window Size W/H:[/]     {terminalInfo.TerminalSize.Value.Width}/{terminalInfo.TerminalSize.Value.Height} ({terminalInfo.TerminalSize.Value.Height / Terminal.Size.Height})
-            [bold]Kitty Graphics:[/]      {terminalInfo.IsKittyProtocolSupported.Value}
             [bold]iTerm2 Graphics:[/]     {terminalInfo.IsITerm2ProtocolSupported.Value}
+            [bold]Kitty Graphics:[/]      {terminalInfo.IsKittyProtocolSupported.Value}
             [bold]Sixel Graphics:[/]      {terminalInfo.IsSixelSupported.Value}
             [bold]Synchronized Output:[/] {terminalInfo.IsSynchronizedOutputSupported.Value}
             [bold]Version:[/]             {ThisAssembly.AssemblyInformationalVersion}

--- a/UndercutF1.Console/Display/TimingHistoryDisplay.cs
+++ b/UndercutF1.Console/Display/TimingHistoryDisplay.cs
@@ -366,30 +366,7 @@ public class TimingHistoryDisplay(
             canvas.DrawText($"Height: {heightPixels}", 5, 40, _errorPaint);
         }
 
-        if (terminalInfo.IsKittyProtocolSupported.Value)
-        {
-            var imageData = surface.Snapshot().Encode();
-            var base64 = Convert.ToBase64String(imageData.AsSpan());
-            return
-            [
-                TerminalGraphics.KittyGraphicsSequenceDelete(),
-                .. TerminalGraphics.KittyGraphicsSequence(heightCells, widthCells, base64),
-            ];
-        }
-        else if (terminalInfo.IsITerm2ProtocolSupported.Value)
-        {
-            var imageData = surface.Snapshot().Encode();
-            var base64 = Convert.ToBase64String(imageData.AsSpan());
-            return [TerminalGraphics.ITerm2GraphicsSequence(heightCells, widthCells, base64)];
-        }
-        else if (terminalInfo.IsSixelSupported.Value)
-        {
-            var bitmap = SKBitmap.FromImage(surface.Snapshot());
-            var sixelData = Sixel.ImageToSixel(bitmap.Pixels, bitmap.Width);
-            return [TerminalGraphics.SixelGraphicsSequence(sixelData)];
-        }
-
-        return ["Unexpected error, shouldn't have got here. Please report!"];
+        return surface.Snapshot().ToGraphicsSequence(terminalInfo, heightCells, widthCells);
     }
 
     private SKCartesianChart CreateChart(

--- a/UndercutF1.Console/Graphics/SKImageExtensions.cs
+++ b/UndercutF1.Console/Graphics/SKImageExtensions.cs
@@ -1,0 +1,42 @@
+using SkiaSharp;
+
+namespace UndercutF1.Console.Graphics;
+
+internal static class SKImageExtensions
+{
+    public static string[] ToGraphicsSequence(
+        this SKImage image,
+        TerminalInfoProvider terminalInfo,
+        int windowHeight,
+        int windowWidth
+    )
+    {
+        if (terminalInfo.IsITerm2ProtocolSupported.Value)
+        {
+            var imageData = image.Encode();
+            var base64 = Convert.ToBase64String(imageData.AsSpan());
+            return [TerminalGraphics.ITerm2GraphicsSequence(windowHeight, windowWidth, base64)];
+        }
+        else if (terminalInfo.IsKittyProtocolSupported.Value)
+        {
+            var imageData = image.Encode();
+            var base64 = Convert.ToBase64String(imageData.AsSpan());
+            return
+            [
+                TerminalGraphics.KittyGraphicsSequenceDelete(),
+                .. TerminalGraphics.KittyGraphicsSequence(windowHeight, windowWidth, base64),
+            ];
+        }
+        else if (terminalInfo.IsSixelSupported.Value)
+        {
+            var bitmap = SKBitmap.FromImage(image);
+            var sixelData = Sixel.ImageToSixel(bitmap.Pixels, bitmap.Width);
+            return [TerminalGraphics.SixelGraphicsSequence(sixelData)];
+        }
+
+        return
+        [
+            "Unexpected error whilst creating graphics, we shouldn't have got here. Please report!",
+        ];
+    }
+}


### PR DESCRIPTION
For some reason the recent iTerm2 release makes the app think it supports Kitty graphics, but displaying Kitty graphics causes issues in the terminal and no image is actually visible. Need to determine why this is happening, but for now it makes sense to prefer the simpler iTerm2 protocol when supported anyway.