### PR TITLE
Cleanup Terminal Graphics queries

### DIFF
--- a/UndercutF1.Console/CommandHandler.Login.cs
+++ b/UndercutF1.Console/CommandHandler.Login.cs
@@ -18,7 +18,7 @@ public static partial class CommandHandler
         var app = builder.Build();
 
         var accountService = app.Services.GetRequiredService<Formula1Account>();
-        var existingPayload = accountService.Payload.Value;
+        var existingPayload = accountService.Payload;
 
         // Allow a relogin on the day of expiry but not before
         if (existingPayload is not null && existingPayload.Expiry.Date != DateTime.Today)

--- a/UndercutF1.Console/ConsoleLoop.cs
+++ b/UndercutF1.Console/ConsoleLoop.cs
@@ -393,7 +393,11 @@ public class ConsoleLoop(
                 modifiers = ConsoleModifiers.None;
                 return true;
             case [ESC, ..]:
-                logger.LogInformation("Unknown esc sequence: {Seq}", string.Join('|', bytes[1..]));
+                logger.LogInformation(
+                    "Unknown esc sequence: {Seq} ({Str})",
+                    string.Join('|', bytes[1..]),
+                    Util.Sanitize(bytes)
+                );
                 break;
             case [var key, .. var remaining]: // Just a normal key press
                 keyChar = (char)key;

--- a/UndercutF1.Console/Display/DriverTrackerDisplay.cs
+++ b/UndercutF1.Console/Display/DriverTrackerDisplay.cs
@@ -134,7 +134,6 @@ public class DriverTrackerDisplay : IDisplay
             }
             else if (_positionData.Latest.Position.Last().Entries.Count == 0)
             {
-                var authStatus = _accountService.IsAuthenticated.Value;
                 trackMapMessage = $"""
 
                     [yellow]Unable to find any Car Position data for the current session.[/]
@@ -143,7 +142,7 @@ public class DriverTrackerDisplay : IDisplay
 
                     If you face any issues, please raise an issue on GitHub at https://github.com/JustAman62/undercut-f1 with the below information and I'd be happy to assist!
 
-                    [bold]F1 TV Account:[/] {authStatus}
+                    [bold]F1 TV Account:[/] {_accountService.IsAuthenticated}
                     """;
             }
         }

--- a/UndercutF1.Console/Display/InfoDisplay.cs
+++ b/UndercutF1.Console/Display/InfoDisplay.cs
@@ -18,8 +18,6 @@ public sealed class InfoDisplay(
 
     public Task<IRenderable> GetContentAsync()
     {
-        var authStatus = accountService.IsAuthenticated.Value;
-        var payload = accountService.Payload.Value;
         var content = $"""
             [bold]Configuration[/]
             [bold]Data Directory:[/]        {options.Value.DataDirectory}
@@ -27,12 +25,12 @@ public sealed class InfoDisplay(
             [bold]Audible Notifications:[/] {options.Value.Notify}
             [bold]Verbose Mode:[/]          {options.Value.Verbose}
             [bold]Forced Protocol:[/]       {options.Value.ForceGraphicsProtocol?.ToString() ?? "None"}
-            [bold]F1 TV Account:[/]         {authStatus}
+            [bold]F1 TV Account:[/]         {accountService.IsAuthenticated}
             [bold]Config Override File:[/]  {File.Exists(
                 Options.ConfigFilePath
             )} ({Options.ConfigFilePath})
             See https://github.com/JustAman62/undercut-f1#configuration for information on how to configure these options.
-            [dim]{payload}[/]
+            [dim]{accountService.Payload}[/]
 
             [bold]Terminal Diagnostics[/]
             [bold]TERM_PROGRAM:[/]        {Environment.GetEnvironmentVariable("TERM_PROGRAM")}

--- a/UndercutF1.Console/Display/MainDisplay.cs
+++ b/UndercutF1.Console/Display/MainDisplay.cs
@@ -27,12 +27,10 @@ public class MainDisplay(
             """
         ).Centered();
 
-        var authStatus = accountService.IsAuthenticated.Value;
-        var payload = accountService.Payload.Value;
-        var accountDetail = authStatus switch
+        var accountDetail = accountService.IsAuthenticated switch
         {
             Formula1Account.AuthenticationResult.Success => $"""
-                [green]Logged in to F1 TV account.[/] Token will expire on [bold]{payload!.Expiry:yyyy-MM-dd}[/]
+                [green]Logged in to F1 TV account.[/] Token will expire on [bold]{accountService.Payload!.Expiry:yyyy-MM-dd}[/]
                 """,
             Formula1Account.AuthenticationResult.ExpiredToken => """
                 [yellow]Formula 1 account token has expired! Please run the following to log back in:[/]

--- a/UndercutF1.Console/Display/SessionStatsDisplay.cs
+++ b/UndercutF1.Console/Display/SessionStatsDisplay.cs
@@ -173,7 +173,6 @@ public sealed class ChampionshipStatsDisplay(
 
         if (championshipPrediction.Latest.Teams.Count == 0)
         {
-            var authStatus = accountService.IsAuthenticated.Value;
             output = new Markup(
                 $"""
                 [yellow]Unable to find championship data for the current session.[/]
@@ -182,7 +181,7 @@ public sealed class ChampionshipStatsDisplay(
 
                 If you face any issues, please raise an issue on GitHub at https://github.com/JustAman62/undercut-f1 with the below information and I'd be happy to assist!
 
-                [bold]F1 TV Account Status:[/] {authStatus}
+                [bold]F1 TV Account Status:[/] {accountService.IsAuthenticated}
                 """
             );
             return true;

--- a/UndercutF1.Console/Graphics/TerminalGraphics.cs
+++ b/UndercutF1.Console/Graphics/TerminalGraphics.cs
@@ -64,6 +64,7 @@ public static class TerminalGraphics
             $"c={width}", // Num rows
             $"f=100" // We'll be sending PNG encoded base64 data
         };
+        var argStr = string.Join(',', args);
 
         return base64EncodedImage
             .Chunk(4000)
@@ -73,14 +74,13 @@ public static class TerminalGraphics
                     {
                         // Start a multi chunk
                         (4000, 0) =>
-                            $"{ESCAPE_APC}{string.Join(',', args)},m=1;{new string(base64Chunk)}{ESCAPE_ST}",
+                            $"{ESCAPE_APC}{argStr},m=1;{new string(base64Chunk)}{ESCAPE_ST}",
                         // Only a single chunk
-                        (_, 0) =>
-                            $"{ESCAPE_APC}{string.Join(',', args)};{new string(base64Chunk)}{ESCAPE_ST}",
+                        (_, 0) => $"{ESCAPE_APC}{argStr};{new string(base64Chunk)}{ESCAPE_ST}",
                         // Middle chunks
-                        (4000, _) => $"{ESCAPE_APC}m=1;{new string(base64Chunk)}{ESCAPE_ST}",
+                        (4000, _) => $"{ESCAPE_APC}q=1,m=1;{new string(base64Chunk)}{ESCAPE_ST}",
                         // Final chunk
-                        (_, _) => $"{ESCAPE_APC}m=0;{new string(base64Chunk)}{ESCAPE_ST}",
+                        (_, _) => $"{ESCAPE_APC}q=1,m=0;{new string(base64Chunk)}{ESCAPE_ST}",
                     }
             )
             .ToArray();

--- a/UndercutF1.Console/TerminalInfoProvider.cs
+++ b/UndercutF1.Console/TerminalInfoProvider.cs
@@ -97,7 +97,7 @@ public sealed partial class TerminalInfoProvider
         }
 
         PrepareTerminal();
-        var buffer = ArrayPool<byte>.Shared.Rent(128);
+        var buffer = RentBuffer();
         try
         {
             // Query the terminal with a graphic protocol specific escape code
@@ -142,7 +142,7 @@ public sealed partial class TerminalInfoProvider
 
     private bool GetSynchronizedOutputSupported()
     {
-        var buffer = ArrayPool<byte>.Shared.Rent(128);
+        var buffer = RentBuffer();
         try
         {
             // Send a DECRQM query to the terminal to check for support
@@ -195,7 +195,7 @@ public sealed partial class TerminalInfoProvider
     private TerminalSizeInfo GetTerminalSize()
     {
         PrepareTerminal();
-        var buffer = ArrayPool<byte>.Shared.Rent(128);
+        var buffer = RentBuffer();
         try
         {
             // Send a DCS query to the terminal to query terminal size
@@ -272,7 +272,7 @@ public sealed partial class TerminalInfoProvider
         }
 
         PrepareTerminal();
-        var buffer = ArrayPool<byte>.Shared.Rent(128);
+        var buffer = RentBuffer();
         try
         {
             // Send a primary device attributes request
@@ -313,9 +313,16 @@ public sealed partial class TerminalInfoProvider
         }
     }
 
-    private void DiscardExtraResponse()
+    private static byte[] RentBuffer()
     {
         var buffer = ArrayPool<byte>.Shared.Rent(128);
+        Array.Fill(buffer, (byte)0);
+        return buffer;
+    }
+
+    private void DiscardExtraResponse()
+    {
+        var buffer = RentBuffer();
         try
         {
             _logger.LogDebug("Reading extra device attr response to discard");

--- a/UndercutF1.Data/Client/LiveTimingClient.cs
+++ b/UndercutF1.Data/Client/LiveTimingClient.cs
@@ -65,7 +65,7 @@ public sealed class LiveTimingClient(
                 configure =>
                 {
                     configure.AccessTokenProvider = () =>
-                        Task.FromResult(formula1Account.AccessToken.Value);
+                        Task.FromResult(formula1Account.AccessToken);
                 }
             )
             .WithAutomaticReconnect()

--- a/UndercutF1.Data/Formula1Account.cs
+++ b/UndercutF1.Data/Formula1Account.cs
@@ -15,18 +15,18 @@ public sealed class Formula1Account
         _options = options;
         _logger = logger;
 
-        Payload = new(CheckToken(out var payload) == AuthenticationResult.Success ? payload : null);
-        IsAuthenticated = new(() => CheckToken(out _));
-        AccessToken = new(
-            IsAuthenticated.Value == AuthenticationResult.Success
+        var authResult = CheckToken(out var payload);
+        Payload = authResult == AuthenticationResult.Success ? payload : null;
+        IsAuthenticated = authResult;
+        AccessToken =
+            authResult == AuthenticationResult.Success
                 ? SubscriptionTokenFromAccessToken(options.Value.Formula1AccessToken!)
-                : null
-        );
+                : null;
     }
 
-    public Lazy<string?> AccessToken { get; }
-    public Lazy<TokenPayload?> Payload { get; }
-    public Lazy<AuthenticationResult> IsAuthenticated { get; }
+    public string? AccessToken { get; }
+    public TokenPayload? Payload { get; }
+    public AuthenticationResult IsAuthenticated { get; }
 
     private AuthenticationResult CheckToken(out TokenPayload? payload) =>
         CheckToken(_options.Value.Formula1AccessToken, out payload);


### PR DESCRIPTION
* Ensure all Kitty chunks are sent with the quiet flag. iTerm2 will otherwise send back a ack response for every chunk (don't think other terminals do this)
* Cleanup terminal info queries to make sure we aren't logging junk memory
* Reduce complexity of the F1 account token logic to prevent duplicate processing