### PR TITLE
Show pit stop times in Tyre Stint screen again

### DIFF
--- a/UndercutF1.Console/Display/TyreStintDisplay.cs
+++ b/UndercutF1.Console/Display/TyreStintDisplay.cs
@@ -8,6 +8,7 @@ public class TyreStintDisplay(
     State state,
     CommonDisplayComponents common,
     PitLaneTimeCollectionProcessor pitLaneTimeCollection,
+    PitStopSeriesProcessor pitStopSeries,
     DriverListProcessor driverList,
     TimingAppDataProcessor timingAppData,
     LapCountProcessor lapCount
@@ -103,9 +104,13 @@ public class TyreStintDisplay(
         var columns = new List<Rows>();
         foreach (var (stintNumber, stint) in line.Stints)
         {
-            var pitStop = pitLaneTimeCollection
+            var pitLaneTime = pitLaneTimeCollection
                 .Latest.PitTimesList.GetValueOrDefault(selectedDriverNumber)
                 ?.ElementAtOrDefault(int.Parse(stintNumber) - 1);
+            var pitStop = pitStopSeries
+                .Latest.PitTimes.GetValueOrDefault(selectedDriverNumber)
+                ?.ElementAtOrDefault(int.Parse(stintNumber) - 1)
+                .Value?.PitStop;
 
             var compoundMarkup = DisplayUtils.GetStyleForTyreCompound(stint.Compound).ToMarkup();
             // Use a consistent tyre compound header to centre it nicely
@@ -129,7 +134,8 @@ public class TyreStintDisplay(
                 ),
                 new($"Total Laps  {stint.TotalLaps:D2}"),
                 new($"Best  {stint.LapTime}"),
-                pitStop is null ? new(" ") : new($"Lane {pitStop?.Duration?.PadLeft(9)}"),
+                pitLaneTime is null ? new(" ") : new($"Lane {pitLaneTime?.Duration?.PadLeft(9)}"),
+                pitStop is null ? new(" ") : new($"Stop {pitStop.PitStopTime?.PadLeft(9)}"),
             };
             columns.Add(new Rows(rows).Collapse());
         }

--- a/UndercutF1.Data/Client/LiveTimingClient.cs
+++ b/UndercutF1.Data/Client/LiveTimingClient.cs
@@ -38,14 +38,13 @@ public sealed class LiveTimingClient(
         "LapCount",
         "TimingData",
         "TeamRadio",
-        // Only available with subscription?
+        // Only available with subscription
         "CarData.z",
         "Position.z",
         "ChampionshipPrediction",
-        // Not sure if these work now?
         "PitLaneTimeCollection",
+        // Only available after a session?
         "PitStopSeries",
-        "PitStop",
     ];
 
     public HubConnection? Connection { get; private set; }


### PR DESCRIPTION
Closes #127 

Adds back the Pit Stop time when looking at tyre stints on the Tyre Stint timing page. This was originally removed because this data is no longer available in the live SignalR. However, this data feed is still available when importing sessions, so we can show it then.