### PR TITLE
Allow selecting two drivers for persistent comparison charts

### DIFF
--- a/UndercutF1.Console/Input/SelectForCompareInputHandler.cs
+++ b/UndercutF1.Console/Input/SelectForCompareInputHandler.cs
@@ -1,0 +1,59 @@
+using UndercutF1.Data;
+
+namespace UndercutF1.Console;
+
+public sealed class SelectForCompareInputHandler(
+    State state,
+    TimingDataProcessor timingData,
+    DriverListProcessor driverList,
+    SessionInfoProcessor sessionInfo
+) : IInputHandler
+{
+    public bool IsEnabled =>
+        sessionInfo.Latest.IsRace()
+        && (
+            state.CursorOffset > 0
+            // Allow reset action at any cursor offset
+            || (state.CompareDrivers is (not null, not null))
+        );
+
+    public Screen[] ApplicableScreens => [Screen.TimingTower];
+
+    public ConsoleKey[] Keys => [ConsoleKey.C];
+
+    public string Description =>
+        state.CompareDrivers switch
+        {
+            (null, null) => "Compare",
+            (var first, null) => $"[olive]Compare with {GetDriverMarkup(first)}[/]",
+            (_, _) => "[olive]Reset Compare[/]",
+        };
+
+    public int Sort => 40;
+
+    public Task ExecuteAsync(
+        ConsoleKeyInfo consoleKeyInfo,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var selectedDriverNumber = timingData
+            .Latest.Lines.FirstOrDefault(x => x.Value.Line == state.CursorOffset)
+            .Key;
+
+        state.CompareDrivers = (selectedDriverNumber, state.CompareDrivers) switch
+        {
+            (null, _) => (null, null),
+            (var driver, (null, null)) => (driver, null),
+            (var driver, (var first, null)) => (first, driver),
+            _ => (null, null),
+        };
+
+        return Task.CompletedTask;
+    }
+
+    private string GetDriverMarkup(string driverNumber)
+    {
+        var driver = driverList.Latest.GetValueOrDefault(driverNumber);
+        return driver is null ? driverNumber : DisplayUtils.MarkedUpDriverNumber(driver);
+    }
+}

--- a/UndercutF1.Console/State.cs
+++ b/UndercutF1.Console/State.cs
@@ -17,4 +17,6 @@ public record State
     }
 
     public int CursorOffset { get; set; } = 0;
+
+    public (string? First, string? Second) CompareDrivers { get; set; } = (null, null);
 }


### PR DESCRIPTION
Closes #126.

In Race sessions, we can now use the <kbd>C</kbd> key when the cursor is on a driver to select that driver as part of a comparison. Selecting a second driver then adds a persistent comparison chart to the button of the screen (similar to the existing comparison which applies when cursor is on a driver already).

Usage:
1. Use the cursor to highlight a driver to compare
2. Press <kbd>C</kbd> to start the comparison
3. Use the cursor to highlight the second driver you want to compare
4. <kbd>C</kbd> to add the current driver at the second part of the compare
5. Comparison charts will now show at the bottom
6. Move the cursor to the top (position 0) to keep show the direct comparison in the Compare tower column as well

One driver selected:
<img width="1512" height="945" alt="Screenshot 2025-11-08 at 16 50 46" src="https://github.com/user-attachments/assets/c32cd5d3-ef4d-4225-8960-ab31e38ef961" />


With two drivers selected:
<img width="1512" height="945" alt="Screenshot 2025-11-08 at 16 50 24" src="https://github.com/user-attachments/assets/94925cfd-23e4-4553-a16b-e1e9941a8f18" />

