### PR TITLE
Upgrade to InhibitSleep.Net 0.1.11 to fix Windows support check

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <PackageVersion Include="AutoMapper" Version="14.0.0" />
     <PackageVersion Include="AutoMapper.Collection" Version="11.0.0" />
     <PackageVersion Include="FFMpegCore" Version="5.4.0" />
-    <PackageVersion Include="InhibitSleep.Net" Version="0.1.6" />
+    <PackageVersion Include="InhibitSleep.Net" Version="0.1.11" />
     <PackageVersion Include="InMemoryLogger" Version="1.0.66" />
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
     <PackageVersion Include="JsonSchema.Net.Generation" Version="5.1.1" />


### PR DESCRIPTION
Closes #142 by upgrading to InhibitSleep.Net 0.1.11 which fixes the Windows `IsSupported` check