### PR TITLE
Set WEBKIT_DISABLE_DMABUF_RENDERER for preemptively handle Nvidia <> Wayland issues

### DIFF
--- a/UndercutF1.Console/CommandHandler.Login.cs
+++ b/UndercutF1.Console/CommandHandler.Login.cs
@@ -132,6 +132,13 @@ public static partial class CommandHandler
 
     private static string? LoginWithWebView()
     {
+        if (OperatingSystem.IsLinux())
+        {
+            // Workaround for Nvidia driver issues and Wayland
+            // See https://github.com/JustAman62/undercut-f1/issues/144
+            Environment.SetEnvironmentVariable("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+
         using var webView = new Webview(debug: false, interceptExternalLinks: false);
 
         var cookie = default(string);


### PR DESCRIPTION
Relates to #144 

Setting the environment variable as a preemptive measure for Linux users who may encounter issues with Nvidia drivers and Wayland. See the related issues for links to similar approaches taken by various other applications.