### PR TITLE
Include more static dependencies for SkiaSharp

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <PackageVersion Include="AutoMapper" Version="14.0.0" />
     <PackageVersion Include="AutoMapper.Collection" Version="11.0.0" />
     <PackageVersion Include="FFMpegCore" Version="5.4.0" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.2" />
     <PackageVersion Include="InhibitSleep.Net" Version="0.1.11" />
     <PackageVersion Include="InMemoryLogger" Version="1.0.66" />
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
@@ -31,7 +32,7 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="SharpWebview" Version="0.11.3" />
     <PackageVersion Include="SkiaSharp" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.1" />
     <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="3.119.1" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="3.119.1" />
     <PackageVersion Include="Spectre.Console" Version="0.48.0" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
 
-# libfontconfig required for SkiaSharp
 # ffmpeg libgdiplus required for ffmpeg
-RUN apt-get update && apt-get install libfontconfig ffmpeg libgdiplus -y
+RUN apt-get update && apt-get install ffmpeg libgdiplus -y
 
 
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS build

--- a/UndercutF1.Console/UndercutF1.Console.csproj
+++ b/UndercutF1.Console/UndercutF1.Console.csproj
@@ -13,6 +13,7 @@
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" />
     <PackageReference Include="InhibitSleep.Net" />
     <PackageReference Include="InMemoryLogger" />
     <PackageReference Include="LiveChartsCore" />
@@ -27,7 +28,7 @@
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="SharpWebview" />
     <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" />
     <PackageReference Include="SkiaSharp.NativeAssets.macOS" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" />
     <PackageReference Include="Spectre.Console" />


### PR DESCRIPTION
Relates to #151

See:
* https://github.com/mono/SkiaSharp/issues/3229
* https://github.com/mono/SkiaSharp/issues/3272

Our docker image fails to render charts due to dependency issues since upgrading to SkiaSharp 3. To attempt to resolve this, we switch to the NoDependencies version of the SkiaSharp library and provide our own Harfbuzz library, to try and avoid dynamic linking issues.