### PR TITLE
Add missing timing data API endpoints

### DIFF
--- a/UndercutF1.Console/Api/TimingEndpoints.cs
+++ b/UndercutF1.Console/Api/TimingEndpoints.cs
@@ -7,14 +7,23 @@ public static class TimingEndpoints
 {
     public static WebApplication MapTimingEndpoints(this WebApplication app)
     {
-        app.MapLatestDataEndpoint<DriverListProcessor, DriverListDataPoint>()
+        app.MapLatestDataEndpoint<CarDataProcessor, CarDataPoint>()
+            .MapLatestDataEndpoint<
+                ChampionshipPredictionProcessor,
+                ChampionshipPredictionDataPoint
+            >()
+            .MapLatestDataEndpoint<DriverListProcessor, DriverListDataPoint>()
             .MapLatestDataEndpoint<ExtrapolatedClockProcessor, ExtrapolatedClockDataPoint>()
             .MapLatestDataEndpoint<HeartbeatProcessor, HeartbeatDataPoint>()
             .MapLatestDataEndpoint<LapCountProcessor, LapCountDataPoint>()
+            .MapLatestDataEndpoint<PitLaneTimeCollectionProcessor, PitLaneTimeCollectionDataPoint>()
+            .MapLatestDataEndpoint<PitStopSeriesProcessor, PitStopSeriesDataPoint>()
+            .MapLatestDataEndpoint<PositionDataProcessor, PositionDataPoint>()
             .MapLatestDataEndpoint<RaceControlMessageProcessor, RaceControlMessageDataPoint>()
             .MapLatestDataEndpoint<SessionInfoProcessor, SessionInfoDataPoint>()
             .MapLatestDataEndpoint<TimingAppDataProcessor, TimingAppDataPoint>()
             .MapLatestDataEndpoint<TimingDataProcessor, TimingDataPoint>()
+            .MapLatestDataEndpoint<TimingStatsProcessor, TimingStatsDataPoint>()
             .MapLatestDataEndpoint<TrackStatusProcessor, TrackStatusDataPoint>()
             .MapLatestDataEndpoint<WeatherProcessor, WeatherDataPoint>();
 

--- a/UndercutF1.Data/Processors/ProcessorHelper.cs
+++ b/UndercutF1.Data/Processors/ProcessorHelper.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace UndercutF1.Data;
+
+public static class ProcessorHelper
+{
+    /// <summary>
+    /// Gets a list of all concreate Processor types, so that they can be generically iterated on.
+    /// Intended for use when registering types in e.g. a <see cref="IServiceCollection"/>
+    /// </summary>
+    public static IEnumerable<(Type ProcessorType, Type DataPointType)> GetProcessorTypes() =>
+        typeof(IProcessor)
+            .Assembly.GetTypes()
+            .Where(x => x.IsClass && x.IsAssignableTo(typeof(IProcessor)) && !x.IsGenericType)
+            .Select(processorType =>
+            {
+                var dataPointType = GetDataPointTypeForProcessorType(processorType);
+                return (processorType, dataPointType);
+            });
+
+    /// <summary>
+    /// Gets the <see cref="Type"/> of the data point which the provided <paramref name="processorType"/> is for
+    /// </summary>
+    public static Type GetDataPointTypeForProcessorType(Type processorType) =>
+        processorType
+            .GetInterfaces()
+            .First(x =>
+                x.IsGenericType
+                && x.GenericTypeArguments.Length > 0
+                && x.GenericTypeArguments.First().IsAssignableTo(typeof(ILiveTimingDataPoint))
+            )
+            .GenericTypeArguments.First();
+}

--- a/UndercutF1.Data/Processors/ServiceCollectionExtensions.cs
+++ b/UndercutF1.Data/Processors/ServiceCollectionExtensions.cs
@@ -6,21 +6,8 @@ public static partial class ServiceCollectionExtensions
 {
     public static IServiceCollection AddLiveTimingProcessors(this IServiceCollection collection)
     {
-        var processorTypes = typeof(IProcessor)
-            .Assembly.GetTypes()
-            .Where(x => x.IsClass && x.IsAssignableTo(typeof(IProcessor)) && !x.IsGenericType);
-
-        foreach (var processorType in processorTypes)
+        foreach (var (processorType, dataPointType) in ProcessorHelper.GetProcessorTypes())
         {
-            var dataPointType = processorType
-                .GetInterfaces()
-                .First(x =>
-                    x.IsGenericType
-                    && x.GenericTypeArguments.Length > 0
-                    && x.GenericTypeArguments.First().IsAssignableTo(typeof(ILiveTimingDataPoint))
-                )
-                .GenericTypeArguments.First();
-
             collection
                 .AddSingleton(typeof(IProcessor), x => x.GetRequiredService(processorType))
                 .AddSingleton(


### PR DESCRIPTION
Relates to #164.

Adds in the missing timing data endpoints for all data point types.

Long term need to add this to source code generation so that this list isn't manually maintained.