### PR TITLE
Generate OpenApi docs using Microsoft.OpenApi instead of Swashbuckle

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="JsonSchema.Net.Generation" Version="6.0.0" />
     <PackageVersion Include="LiveChartsCore" Version="2.0.0-rc6.1" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView" Version="2.0.0-rc6.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="7.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
@@ -36,7 +36,7 @@
     <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="3.119.1" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="3.119.1" />
     <PackageVersion Include="Spectre.Console" Version="0.54.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.2" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.6" />
     <PackageVersion Include="TextCopy" Version="6.2.1" />

--- a/UndercutF1.Console/CommandHandler.Root.cs
+++ b/UndercutF1.Console/CommandHandler.Root.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.OpenApi.Models;
+using System.Text.Json.Serialization.Metadata;
 using UndercutF1.Console.Api;
 using UndercutF1.Console.Audio;
 using UndercutF1.Console.ExternalPlayerSync;
@@ -50,21 +50,16 @@ public static partial class CommandHandler
         {
             builder.WebHost.UseKestrel(opt => opt.ListenAnyIP(0xF1F1)); // listens on 61937
 
-            builder
-                .Services.AddRouting()
-                .AddEndpointsApiExplorer()
-                .AddSwaggerGen(c =>
+            builder.Services.AddOpenApi(
+                "v1",
+                opts =>
                 {
-                    c.CustomSchemaIds(type =>
-                        type.FullName!.Replace("UndercutF1.Data.", string.Empty)
-                            .Replace("UndercutF1.Console.Api.", string.Empty)
-                            .Replace("+", string.Empty)
-                    );
-                    c.SwaggerDoc(
-                        "v1",
-                        new OpenApiInfo { Title = "Undercut F1 API", Version = "v1" }
-                    );
-                });
+                    opts.CreateSchemaReferenceId = CreateSchemaReferenceId;
+                    opts.OpenApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi3_0;
+                }
+            );
+
+            builder.Services.AddRouting().AddEndpointsApiExplorer();
         }
 
         builder.Services.Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>(x =>
@@ -84,9 +79,9 @@ public static partial class CommandHandler
 
         if (options.ApiEnabled)
         {
-            app.UseSwagger().UseSwaggerUI();
+            app.MapOpenApi();
 
-            app.MapSwagger();
+            app.UseSwaggerUI(opts => opts.SwaggerEndpoint("/openapi/v1.json", "v1"));
 
             app.MapControlEndpoints().MapTimingEndpoints();
         }
@@ -125,5 +120,17 @@ public static partial class CommandHandler
 
         await EnsureConfigFileExistsAsync(app.Logger);
         await app.RunAsync();
+    }
+
+    private static string? CreateSchemaReferenceId(JsonTypeInfo typeInfo)
+    {
+        var name = typeInfo.Type.FullName;
+
+        // Don't create references for simple types like bools
+        return name is null || name.StartsWith("System")
+            ? null
+            : name.Replace("UndercutF1.Data.", string.Empty)
+                .Replace("UndercutF1.Console.Api.", string.Empty)
+                .Replace("+", string.Empty);
     }
 }

--- a/UndercutF1.Console/UndercutF1.Console.csproj
+++ b/UndercutF1.Console/UndercutF1.Console.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="InMemoryLogger" />
     <PackageReference Include="LiveChartsCore" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Sinks.File" />
@@ -27,7 +28,7 @@
     <PackageReference Include="SkiaSharp.NativeAssets.macOS" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" />
     <PackageReference Include="Spectre.Console" />
-    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="TextCopy" />
     <PackageReference Include="Vezel.Cathode" />


### PR DESCRIPTION
Removing the need for the full Swashbuckle.AspNetCore library reduces the risk of relying on non-aot compatible libraries (Swashbuckle.AspNetCore produces trim warnings)