### PR TITLE
Serialize imported data in to single lines

### DIFF
--- a/UndercutF1.Data/Json/TimingDataSerializerContext.cs
+++ b/UndercutF1.Data/Json/TimingDataSerializerContext.cs
@@ -100,7 +100,7 @@ public partial class TimingDataSerializerContext : JsonSerializerContext
                 {
                     UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
                     AllowTrailingCommas = true,
-                    WriteIndented = true,
+                    WriteIndented = false,
                     Converters = { new StringToBoolConverter() },
                 }
             )


### PR DESCRIPTION
The raw serialiser settings should not be writing indented - this caused the data importer to write the data incorrectly