### PR TITLE
Remove DRS car data channel, as it's no longer available in 2026

### DIFF
--- a/UndercutF1.Console/Display/DisplaysUtils.cs
+++ b/UndercutF1.Console/Display/DisplaysUtils.cs
@@ -61,7 +61,6 @@ public static class DisplayUtils
     public static Style GetStyle(
         TimingDataPoint.Driver.Interval? interval,
         bool isComparisonLine,
-        CarDataPoint.Entry.Car? car = null,
         Decoration decoration = Decoration.None
     )
     {
@@ -82,11 +81,6 @@ public static class DisplayUtils
             foreground = Color.Green3;
         }
 
-        if (car is { Channels: { Drs: > 8 } })
-        {
-            foreground = Color.White;
-            background = Color.Green3;
-        }
         return new Style(foreground: foreground, background: background, decoration: decoration);
     }
 

--- a/UndercutF1.Console/Display/DriverTrackerDisplay.cs
+++ b/UndercutF1.Console/Display/DriverTrackerDisplay.cs
@@ -225,15 +225,8 @@ public class DriverTrackerDisplay : IDisplay
                             decoration
                         )
                         : new Text(
-                            $"{(car?.Channels.Drs >= 8 ? "•" : "")}{line.IntervalToPositionAhead?.Value}".ToFixedWidth(
-                                7
-                            ),
-                            DisplayUtils.GetStyle(
-                                line.IntervalToPositionAhead,
-                                false,
-                                car,
-                                decoration
-                            )
+                            $"{line.IntervalToPositionAhead?.Value}".ToFixedWidth(7),
+                            DisplayUtils.GetStyle(line.IntervalToPositionAhead, false, decoration)
                         )
                 );
             }

--- a/UndercutF1.Console/Display/TimingTowerDisplay.cs
+++ b/UndercutF1.Console/Display/TimingTowerDisplay.cs
@@ -138,10 +138,8 @@ public class TimingTowerDisplay(
                 position.Status == PositionDataPoint.PositionData.Entry.DriverStatus.OffTrack
                     ? new Text("OFF TRK", new Style(background: Color.Red, foreground: Color.White))
                     : new Text(
-                        $"{(car?.Channels.Drs >= 8 ? "•" : "")}{line.IntervalToPositionAhead?.Value}".ToFixedWidth(
-                            8
-                        ),
-                        DisplayUtils.GetStyle(line.IntervalToPositionAhead, isComparisonLine, car)
+                        $"{line.IntervalToPositionAhead?.Value}".ToFixedWidth(8),
+                        DisplayUtils.GetStyle(line.IntervalToPositionAhead, isComparisonLine)
                     ),
                 new Text(
                     line.BestLapTime?.Value ?? "NULL",

--- a/UndercutF1.Data/Client/TimingService.cs
+++ b/UndercutF1.Data/Client/TimingService.cs
@@ -259,7 +259,7 @@ public class TimingService(
         try
         {
             // Remove the _kf property, it's not needed and breaks deserialization
-            json["_kf"] = null;
+            json.AsObject().Remove("_kf");
 
             var model = json.Deserialize(TimingDataSerializerContext.Raw.GetTypeInfo<T>())!;
             processors

--- a/UndercutF1.Data/Models/TimingDataPoints/CarDataPoint.cs
+++ b/UndercutF1.Data/Models/TimingDataPoints/CarDataPoint.cs
@@ -39,21 +39,6 @@ public sealed partial record CarDataPoint : ILiveTimingDataPoint
 
                 [JsonPropertyName("5")]
                 public int? Brake { get; set; }
-
-                /// <summary>
-                /// From FastF1s understanding of this field:
-                /// - DRS: 0-14 (Odd DRS is Disabled, Even DRS is Enabled?)
-                ///  - 0 =  Off
-                ///  - 1 =  Off
-                ///  - 2 =  (?)
-                ///  - 3 =  (?)
-                ///  - 8 =  Detected, Eligible once in Activation Zone (Noted Sometimes)
-                ///  - 10 = On (Unknown Distinction)
-                ///  - 12 = On (Unknown Distinction)
-                ///  - 14 = On (Unknown Distinction)
-                /// </summary>
-                [JsonPropertyName("45")]
-                public int? Drs { get; set; }
             }
         }
     }


### PR DESCRIPTION
Channel 45 is now always null as DRS is gone. Checked through the channels sent to us on Day 1 of Bahrain testing, and no new channels exist (at least none yet that I can see).