### PR TITLE
Dim compound text when a driver puts used tyres on

### DIFF
--- a/UndercutF1.Console/Display/DisplaysUtils.cs
+++ b/UndercutF1.Console/Display/DisplaysUtils.cs
@@ -58,6 +58,33 @@ public static class DisplayUtils
     public static string MarkedUpDriverNumber(DriverListDataPoint.Driver driver) =>
         $"[#{driver.TeamColour ?? "000000"} bold]{driver.RacingNumber, 2} {driver.Tla ?? "UNK"}[/]";
 
+    public static string MarkedUpTyreStint(
+        TimingAppDataPoint.Driver.Stint? stint,
+        int width,
+        bool displayFullAge
+    )
+    {
+        if (stint is null)
+        {
+            return string.Empty.ToFixedWidth(width);
+        }
+        var compoundIdentifier = stint.Compound?[0] ?? ' ';
+        var text = stint.New.GetValueOrDefault()
+            ? $"{compoundIdentifier}"
+            : $"[dim]{compoundIdentifier}[/]";
+
+        if (width > 1)
+        {
+            var stintDuration = displayFullAge
+                ? $"{stint.TotalLaps}"
+                : $"{stint.GetStintDuration()}";
+            text += stintDuration.ToFixedWidth(width - 1);
+        }
+
+        var style = GetStyleForTyreCompound(stint.Compound).ToMarkup();
+        return $"[{style}]{text}[/]";
+    }
+
     public static Style GetStyle(
         TimingDataPoint.Driver.Interval? interval,
         bool isComparisonLine,

--- a/UndercutF1.Console/Display/TimingTowerDisplay.cs
+++ b/UndercutF1.Console/Display/TimingTowerDisplay.cs
@@ -172,10 +172,7 @@ public class TimingTowerDisplay(
                             ? new Style(foreground: Color.Black, background: Color.Green)
                         : Style.Plain
                 ),
-                new Text(
-                    $"{stint?.Compound?[0]} {stint?.TotalLaps, 2}",
-                    DisplayUtils.GetStyle(stint)
-                ),
+                new Markup(DisplayUtils.MarkedUpTyreStint(stint, 4, displayFullAge: true)),
                 DisplayUtils.GetGapBetweenLines(
                     lines,
                     comparisonDataPoint.Key,
@@ -295,10 +292,7 @@ public class TimingTowerDisplay(
                         : line.PitOut.GetValueOrDefault() ? DisplayUtils.STYLE_PB
                         : Style.Plain
                 ),
-                new Text(
-                    $"{stint?.Compound?[0] ?? 'X'} {stint?.TotalLaps, 2}",
-                    DisplayUtils.GetStyle(stint)
-                )
+                new Markup(DisplayUtils.MarkedUpTyreStint(stint, 4, displayFullAge: true))
             );
         }
         return table;

--- a/UndercutF1.Console/Display/TyreStintDisplay.cs
+++ b/UndercutF1.Console/Display/TyreStintDisplay.cs
@@ -62,19 +62,14 @@ public class TyreStintDisplay(
 
             foreach (var (stintNumber, stint) in line.Stints.OrderBy(x => x.Key))
             {
-                var markup = DisplayUtils.GetStyleForTyreCompound(stint.Compound).ToMarkup();
                 var lapsOnThisTyre = stint.GetStintDuration();
-
-                var padLength = Math.Max(1, lapsOnThisTyre - 1);
-                var text = $"{lapsOnThisTyre}".ToFixedWidth(padLength);
-                if (lapsOnThisTyre <= 1)
-                {
-                    text = string.Empty;
-                }
-                lineTotalPadLength += text.Length + 1;
-
-                // Prepend the compound indicator, and wrap the whole line in markup to colour it
-                rowMarkup += $"[{markup}]{stint.Compound?[0] ?? ' '}{text}[/]";
+                var stintLength = Math.Max(1, lapsOnThisTyre);
+                lineTotalPadLength += stintLength;
+                rowMarkup += DisplayUtils.MarkedUpTyreStint(
+                    stint,
+                    stintLength,
+                    displayFullAge: false
+                );
             }
 
             if (totalLapCount > 0)


### PR DESCRIPTION
In the Tyre Stint and Timing Tower displays, when a driver put on old tyres the compount identifier text (i.e. the S/M etc) will be dimmed to make it clear they've put on a used tyre