### PR TITLE
Support extra informational fields in RaceControlMessages

### DIFF
--- a/UndercutF1.Data/Models/TimingDataPoints/RaceControlMessageDataPoint.cs
+++ b/UndercutF1.Data/Models/TimingDataPoints/RaceControlMessageDataPoint.cs
@@ -15,5 +15,10 @@ public sealed partial record RaceControlMessageDataPoint : ILiveTimingDataPoint
     {
         public DateTimeOffset Utc { get; set; }
         public string? Message { get; set; }
+        public string? Category { get; set; }
+        public int? Lap { get; set; }
+        public string? Flag { get; set; }
+        public string? Scope { get; set; }
+        public string? RacingNumber { get; set; }
     }
 }


### PR DESCRIPTION
Relates to #237 

Support the extra fields in the RaceControlMessage datapoints, and expose them via the API