### PR TITLE
Fix deserialization of github tags for version check

### DIFF
--- a/UndercutF1.Console/Display/MainDisplay.cs
+++ b/UndercutF1.Console/Display/MainDisplay.cs
@@ -107,7 +107,7 @@ public class MainDisplay(
         var httpClient = httpClientFactory.CreateClient("Default");
         var res = await httpClient.GetFromJsonAsync(
             "https://api.github.com/repos/justaman62/undercut-f1/tags",
-            ConsoleSerializerContext.Default.GitHubTagEntryArray
+            ConsoleSerializerContext.Pretty.GitHubTagEntryArray
         );
         var tag = res?.FirstOrDefault()?.Name;
         logger.LogInformation("Latest tag from GitHub: {Tag}", tag);


### PR DESCRIPTION
The name property wasn't deserialised correctly due to it being in camelcase, and the serialiser context used didn't support that